### PR TITLE
add: a first-pass logs command

### DIFF
--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -44,12 +44,19 @@ type serviceLogResult struct {
 	Output string
 }
 
+type serviceLogError struct {
+	Name string
+	Unit string
+	Err  error
+}
+
 type logsResult struct {
 	AgentName string
 	Target    string
 	Lines     int
 	Service   string
 	Sections  []serviceLogResult
+	Warnings  []serviceLogError
 }
 
 func newLogsCommand(app *App) *cobra.Command {
@@ -62,9 +69,10 @@ func newLogsCommand(app *App) *cobra.Command {
 	var agentsDir string
 
 	cmd := &cobra.Command{
-		Use:     "logs",
-		Short:   "Fetch recent logs for a deployed agent",
-		GroupID: "runtime",
+		Use:          "logs",
+		Short:        "Fetch recent logs for a deployed agent",
+		GroupID:      "runtime",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath := strings.TrimSpace(app.opts.ConfigPath)
 			if configPath == "" {
@@ -183,6 +191,11 @@ func runLogsWorkflow(ctx context.Context, profile string, cfg *config.Config, op
 	for _, target := range targets {
 		output, fetchErr := fetchServiceLogs(ctx, exec, target.Unit, opts.Lines)
 		if fetchErr != nil {
+			serviceErr := serviceLogError{Name: target.Name, Unit: target.Unit, Err: fetchErr}
+			if service == logServiceAll && target.Name == logServiceIntegration && isMissingServiceUnitError(fetchErr) {
+				result.Warnings = append(result.Warnings, serviceErr)
+				continue
+			}
 			errs = append(errs, fmt.Errorf("%s logs (%s): %w", target.Name, target.Unit, fetchErr))
 			continue
 		}
@@ -249,6 +262,14 @@ func fetchServiceLogs(ctx context.Context, exec host.Executor, unit string, line
 	return output, nil
 }
 
+func isMissingServiceUnitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "service unit") &&
+		strings.Contains(strings.ToLower(err.Error()), "is not installed")
+}
+
 func printLogsResult(out io.Writer, result logsResult) {
 	if strings.TrimSpace(result.AgentName) != "" {
 		fmt.Fprintf(out, "agent: %s\n", result.AgentName)
@@ -276,5 +297,8 @@ func printLogsResult(out io.Writer, result logsResult) {
 	}
 	if len(result.Sections) > 0 {
 		fmt.Fprintln(out)
+	}
+	for _, warning := range result.Warnings {
+		fmt.Fprintf(out, "warning: %s logs (%s): %s\n", warning.Name, warning.Unit, warning.Err)
 	}
 }

--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -1,0 +1,280 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"agenthub/internal/config"
+	"agenthub/internal/host"
+	"agenthub/internal/prompt"
+)
+
+const (
+	logServiceRuntime     = "runtime"
+	logServiceIntegration = "integration"
+	logServiceAll         = "all"
+	defaultLogLines       = 100
+)
+
+type logsOptions struct {
+	ConfigPath string
+	Target     string
+	SSHUser    string
+	SSHKey     string
+	SSHPort    int
+	Service    string
+	Lines      int
+}
+
+type serviceLogTarget struct {
+	Name string
+	Unit string
+}
+
+type serviceLogResult struct {
+	Name   string
+	Unit   string
+	Output string
+}
+
+type logsResult struct {
+	AgentName string
+	Target    string
+	Lines     int
+	Service   string
+	Sections  []serviceLogResult
+}
+
+func newLogsCommand(app *App) *cobra.Command {
+	var target string
+	var sshUser string
+	var sshKey string
+	var sshPort int
+	var service string
+	var lines int
+	var agentsDir string
+
+	cmd := &cobra.Command{
+		Use:     "logs",
+		Short:   "Fetch recent logs for a deployed agent",
+		GroupID: "runtime",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath := strings.TrimSpace(app.opts.ConfigPath)
+			if configPath == "" {
+				session := prompt.NewSession(cmd.InOrStdin(), cmd.OutOrStdout())
+				selectedConfigPath, err := selectAgentConfigPath(session, agentsDir)
+				if err != nil {
+					return err
+				}
+				configPath = selectedConfigPath
+			}
+
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return err
+			}
+			if err := config.Validate(cfg); err != nil {
+				return err
+			}
+
+			logger := loggerFromContext(cmd.Context())
+			logger.Info("starting logs workflow")
+			fmt.Fprintln(cmd.OutOrStdout(), "fetching service logs...")
+
+			result, err := runLogsWorkflow(cmd.Context(), app.opts.Profile, cfg, logsOptions{
+				ConfigPath: configPath,
+				Target:     target,
+				SSHUser:    sshUser,
+				SSHKey:     sshKey,
+				SSHPort:    sshPort,
+				Service:    service,
+				Lines:      lines,
+			})
+			printLogsResult(cmd.OutOrStdout(), result)
+			if err != nil {
+				return wrapUserFacingError(
+					"logs retrieval failed",
+					err,
+					"the target host is unreachable or one of the requested services is not installed",
+					"confirm the host is reachable over SSH and rerun "+commandRef(cmd.OutOrStdout(), "agenthub", "logs", "--config", configPath),
+					"adjust "+commandRef(cmd.OutOrStdout(), "--service", "runtime")+" or "+commandRef(cmd.OutOrStdout(), "--service", "integration")+" if only one service is expected on the host",
+				)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&target, "target", "", "SSH target host or EC2 instance id; defaults to infra.instance_id")
+	cmd.Flags().StringVar(&sshUser, "ssh-user", "", "SSH username for the target host")
+	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key")
+	cmd.Flags().IntVar(&sshPort, "ssh-port", 22, "SSH port")
+	cmd.Flags().StringVar(&service, "service", logServiceAll, "service logs to fetch: runtime, integration, or all")
+	cmd.Flags().IntVar(&lines, "lines", defaultLogLines, "number of recent log lines to fetch per service")
+	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
+	return cmd
+}
+
+func runLogsWorkflow(ctx context.Context, profile string, cfg *config.Config, opts logsOptions) (logsResult, error) {
+	if cfg == nil {
+		return logsResult{}, errors.New("config is required")
+	}
+
+	service := strings.ToLower(strings.TrimSpace(opts.Service))
+	if service == "" {
+		service = logServiceAll
+	}
+	if opts.Lines <= 0 {
+		return logsResult{}, errors.New("lines must be greater than 0")
+	}
+
+	targetValue := strings.TrimSpace(opts.Target)
+	if targetValue == "" {
+		targetValue = strings.TrimSpace(cfg.Infra.InstanceID)
+	}
+	if targetValue == "" {
+		return logsResult{}, errors.New("target is required: pass --target or run agenthub create first so infra.instance_id is recorded")
+	}
+
+	agentName := agentNameFromConfigPath(opts.ConfigPath)
+	if agentName == "" {
+		agentName = "default"
+	}
+
+	resolvedTarget, err := resolveHostTarget(ctx, profile, cfg, targetValue)
+	if err != nil {
+		return logsResult{}, err
+	}
+	user, keyPath, err := resolveInstallSSH(cfg, opts.SSHUser, opts.SSHKey)
+	if err != nil {
+		return logsResult{}, err
+	}
+
+	exec := newSSHExecutor(host.SSHConfig{
+		Host:           resolvedTarget,
+		Port:           opts.SSHPort,
+		User:           user,
+		IdentityFile:   keyPath,
+		ConnectTimeout: 15 * time.Second,
+	})
+	if err := waitForSSHReady(ctx, exec, resolvedTarget); err != nil {
+		return logsResult{}, err
+	}
+
+	targets, err := resolveLogTargets(service, agentName)
+	if err != nil {
+		return logsResult{}, err
+	}
+
+	result := logsResult{
+		AgentName: agentName,
+		Target:    resolvedTarget,
+		Lines:     opts.Lines,
+		Service:   service,
+	}
+
+	var errs []error
+	for _, target := range targets {
+		output, fetchErr := fetchServiceLogs(ctx, exec, target.Unit, opts.Lines)
+		if fetchErr != nil {
+			errs = append(errs, fmt.Errorf("%s logs (%s): %w", target.Name, target.Unit, fetchErr))
+			continue
+		}
+		result.Sections = append(result.Sections, serviceLogResult{
+			Name:   target.Name,
+			Unit:   target.Unit,
+			Output: output,
+		})
+	}
+
+	return result, errors.Join(errs...)
+}
+
+func resolveLogTargets(service, agentName string) ([]serviceLogTarget, error) {
+	switch strings.ToLower(strings.TrimSpace(service)) {
+	case logServiceRuntime:
+		return []serviceLogTarget{{Name: logServiceRuntime, Unit: "agenthub.service"}}, nil
+	case logServiceIntegration:
+		return []serviceLogTarget{{Name: logServiceIntegration, Unit: slackServiceNameForAgent(agentName) + ".service"}}, nil
+	case logServiceAll:
+		return []serviceLogTarget{
+			{Name: logServiceRuntime, Unit: "agenthub.service"},
+			{Name: logServiceIntegration, Unit: slackServiceNameForAgent(agentName) + ".service"},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported service %q: expected runtime, integration, or all", service)
+	}
+}
+
+func fetchServiceLogs(ctx context.Context, exec host.Executor, unit string, lines int) (string, error) {
+	if exec == nil {
+		return "", errors.New("executor is required")
+	}
+	if strings.TrimSpace(unit) == "" {
+		return "", errors.New("service unit is required")
+	}
+	if lines <= 0 {
+		return "", errors.New("lines must be greater than 0")
+	}
+
+	script := strings.Join([]string{
+		"set -eu",
+		"unit=" + strconv.Quote(strings.TrimSpace(unit)),
+		"if ! systemctl list-unit-files --full --no-legend \"$unit\" 2>/dev/null | awk '{print $1}' | grep -Fxq \"$unit\"; then",
+		"  echo \"service unit $unit is not installed on the target host\" >&2",
+		"  exit 1",
+		"fi",
+		"journalctl --no-pager --output short-iso -n " + strconv.Itoa(lines) + " -u \"$unit\"",
+	}, "\n")
+
+	result, err := exec.Run(ctx, "sudo", "sh", "-lc", script)
+	if err != nil {
+		msg := strings.TrimSpace(firstNonEmpty(result.Stderr, result.Stdout))
+		if msg != "" {
+			return "", errors.New(msg)
+		}
+		return "", err
+	}
+
+	output := strings.TrimSpace(result.Stdout)
+	if output == "" {
+		return "no log entries returned", nil
+	}
+	return output, nil
+}
+
+func printLogsResult(out io.Writer, result logsResult) {
+	if strings.TrimSpace(result.AgentName) != "" {
+		fmt.Fprintf(out, "agent: %s\n", result.AgentName)
+	}
+	if strings.TrimSpace(result.Target) != "" {
+		fmt.Fprintf(out, "target: %s\n", result.Target)
+	}
+	if result.Lines > 0 {
+		fmt.Fprintf(out, "lines: %d\n", result.Lines)
+	}
+	if len(result.Sections) == 0 {
+		return
+	}
+
+	for i, section := range result.Sections {
+		if i == 0 {
+			fmt.Fprintln(out)
+		} else {
+			fmt.Fprintln(out)
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "%s logs (%s)\n", section.Name, section.Unit)
+		fmt.Fprintln(out, strings.Repeat("-", len(section.Name)+len(section.Unit)+8))
+		fmt.Fprint(out, strings.TrimRight(section.Output, "\n"))
+	}
+	if len(result.Sections) > 0 {
+		fmt.Fprintln(out)
+	}
+}

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -60,6 +60,7 @@ func newRootCommand(app *App) *cobra.Command {
 	rootCmd.AddCommand(newInstallCommand(app))
 	rootCmd.AddCommand(newRedeployCommand(app))
 	rootCmd.AddCommand(newVerifyCommand(app))
+	rootCmd.AddCommand(newLogsCommand(app))
 
 	return rootCmd
 }

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -1156,6 +1156,173 @@ runtime:
 	}
 }
 
+func TestLogsCommandFetchesRuntimeAndIntegrationLogs(t *testing.T) {
+	restore := stubAWSProviderFactory()
+	defer restore()
+
+	originalExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				if command == "sudo" && len(args) >= 3 && args[0] == "sh" && args[1] == "-lc" {
+					script := args[2]
+					switch {
+					case strings.Contains(script, `unit="agenthub.service"`):
+						return host.CommandResult{Stdout: "2026-04-10T12:00:00Z runtime started\n2026-04-10T12:00:01Z runtime healthy\n"}, nil
+					case strings.Contains(script, `unit="agenthub-slack-alpha.service"`):
+						return host.CommandResult{Stdout: "2026-04-10T12:00:02Z slack connected\n"}, nil
+					}
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + command + " " + strings.Join(args, " "))
+			},
+		}
+	}
+	defer func() { newSSHExecutor = originalExecutor }()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "demo.pem")
+	if err := os.WriteFile(keyPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	agentDir := filepath.Join(dir, "agents", "alpha")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	path := filepath.Join(agentDir, "config.yaml")
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+ssh:
+  private_key_path: `+keyPath+`
+  user: ubuntu
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+  network_mode: public
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+  network_mode: public
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "--config", path, "logs", "--ssh-user", "ubuntu", "--ssh-key", keyPath, "--lines", "20"}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	got := stdout.String()
+	for _, fragment := range []string{
+		"fetching service logs...",
+		"agent: alpha",
+		"target: 203.0.113.10",
+		"lines: 20",
+		"runtime logs (agenthub.service)",
+		"2026-04-10T12:00:00Z runtime started",
+		"integration logs (agenthub-slack-alpha.service)",
+		"2026-04-10T12:00:02Z slack connected",
+	} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("stdout = %q, want %q", got, fragment)
+		}
+	}
+}
+
+func TestLogsCommandReturnsServiceSpecificErrors(t *testing.T) {
+	restore := stubAWSProviderFactory()
+	defer restore()
+
+	originalExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				if command == "sudo" && len(args) >= 3 && args[0] == "sh" && args[1] == "-lc" {
+					script := args[2]
+					if strings.Contains(script, `unit="agenthub-slack-alpha.service"`) {
+						return host.CommandResult{Stderr: "service unit agenthub-slack-alpha.service is not installed on the target host"}, errors.New("missing unit")
+					}
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + command + " " + strings.Join(args, " "))
+			},
+		}
+	}
+	defer func() { newSSHExecutor = originalExecutor }()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "demo.pem")
+	if err := os.WriteFile(keyPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	agentDir := filepath.Join(dir, "agents", "alpha")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	path := filepath.Join(agentDir, "config.yaml")
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+ssh:
+  private_key_path: `+keyPath+`
+  user: ubuntu
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+  network_mode: public
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+  network_mode: public
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "--config", path, "logs", "--service", "integration", "--ssh-user", "ubuntu", "--ssh-key", keyPath}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	msg := err.Error()
+	for _, fragment := range []string{
+		"logs retrieval failed",
+		"integration logs (agenthub-slack-alpha.service)",
+		"service unit agenthub-slack-alpha.service is not installed on the target host",
+	} {
+		if !strings.Contains(msg, fragment) {
+			t.Fatalf("error = %q, want %q", msg, fragment)
+		}
+	}
+}
+
 func TestRunRedeployWorkflowFailsWhenVerificationFails(t *testing.T) {
 	originalBuildRuntimeBinary := runtimeinstall.BuildRuntimeBinaryFunc
 	runtimeinstall.BuildRuntimeBinaryFunc = func(ctx context.Context) (string, error) {

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -1243,6 +1243,91 @@ sandbox:
 	}
 }
 
+func TestLogsCommandWarnsWhenIntegrationServiceIsMissingForAll(t *testing.T) {
+	restore := stubAWSProviderFactory()
+	defer restore()
+
+	originalExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				if command == "sudo" && len(args) >= 3 && args[0] == "sh" && args[1] == "-lc" {
+					script := args[2]
+					switch {
+					case strings.Contains(script, `unit="agenthub.service"`):
+						return host.CommandResult{Stdout: "2026-04-10T12:00:00Z runtime started\n"}, nil
+					case strings.Contains(script, `unit="agenthub-slack-alpha.service"`):
+						return host.CommandResult{Stderr: "service unit agenthub-slack-alpha.service is not installed on the target host"}, errors.New("missing unit")
+					}
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + command + " " + strings.Join(args, " "))
+			},
+		}
+	}
+	defer func() { newSSHExecutor = originalExecutor }()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "demo.pem")
+	if err := os.WriteFile(keyPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	agentDir := filepath.Join(dir, "agents", "alpha")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	path := filepath.Join(agentDir, "config.yaml")
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+ssh:
+  private_key_path: `+keyPath+`
+  user: ubuntu
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+  network_mode: public
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+  network_mode: public
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "--config", path, "logs", "--ssh-user", "ubuntu", "--ssh-key", keyPath}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	got := stdout.String()
+	for _, fragment := range []string{
+		"runtime logs (agenthub.service)",
+		"2026-04-10T12:00:00Z runtime started",
+		"warning: integration logs (agenthub-slack-alpha.service): service unit agenthub-slack-alpha.service is not installed on the target host",
+	} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("stdout = %q, want %q", got, fragment)
+		}
+	}
+	if strings.Contains(got, "Usage:") {
+		t.Fatalf("stdout = %q, did not expect usage output", got)
+	}
+}
+
 func TestLogsCommandReturnsServiceSpecificErrors(t *testing.T) {
 	restore := stubAWSProviderFactory()
 	defer restore()
@@ -1320,6 +1405,9 @@ sandbox:
 		if !strings.Contains(msg, fragment) {
 			t.Fatalf("error = %q, want %q", msg, fragment)
 		}
+	}
+	if strings.Contains(stdout.String(), "Usage:") {
+		t.Fatalf("stdout = %q, did not expect usage output", stdout.String())
 	}
 }
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #64 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

  The CLI now has agenthub logs, wired into the root command at internal/app/root.go:45. The
  implementation is in internal/app/logs.go:55: it reuses the existing config selection, instance/
  host resolution, SSH readiness, and SSH credential flow; defaults to infra.instance_id; and
  fetches recent journalctl output for agenthub.service and the per-agent Slack unit. The first
  version deliberately answers the open questions by using one command with --service runtime|
  integration|all and recent logs via --lines only, no follow mode yet.

  I also added coverage for the success path and clear service-specific failure reporting in
  internal/app/root_test.go:1159.

  Verification: go test ./internal/app -run 'TestLogsCommand|TestVerifyCommandReportsSuccess' and go
  test ./internal/app both passed.

  Example usage:
```bash
  agenthub logs --config agents/alpha/config.yaml
  agenthub logs --config agents/alpha/config.yaml --service runtime --lines 200
```

```
fetching service logs...
agent: test
target: 54.178.67.4
lines: 100

runtime logs (agenthub.service)
-------------------------------
2026-04-09T23:56:54+0000 ip-172-31-9-185 systemd[1]: Started AgentHub runtime.
2026-04-09T23:56:55+0000 ip-172-31-9-185 agenthub[4640]: runtime server listening on 0.0.0.0:8080
warning: integration logs (agenthub-slack-test.service): service unit agenthub-slack-test.service is not installed on the target host
```

<!-- close -->
