### PR TITLE
runtime service start

### DIFF
--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -31,6 +31,12 @@ Re-apply runtime deployment to an existing host:
 agenthub redeploy --config agenthub.yaml
 ```
 
+Start the runtime service for one deployed agent:
+
+```bash
+agenthub runtime start --config agenthub.yaml
+```
+
 Show merged agent config status under `agents/`:
 
 ```bash

--- a/internal/app/inspect.go
+++ b/internal/app/inspect.go
@@ -418,12 +418,19 @@ func printInspectService(out io.Writer, label string, state inspectServiceState,
 		fmt.Fprintf(out, "- %s: unavailable: %v\n", label, err)
 		return
 	}
-	if strings.TrimSpace(state.Unit) == "" {
+	summary := formatInspectServiceSummary(state)
+	if summary == "" {
 		return
 	}
+	fmt.Fprintf(out, "- %s: %s\n", label, summary)
+}
+
+func formatInspectServiceSummary(state inspectServiceState) string {
+	if strings.TrimSpace(state.Unit) == "" {
+		return ""
+	}
 	if !state.Installed {
-		fmt.Fprintf(out, "- %s: not installed (%s)\n", label, state.Unit)
-		return
+		return fmt.Sprintf("not installed (%s)", state.Unit)
 	}
 	parts := []string{state.Unit}
 	if value := strings.TrimSpace(state.ActiveState); value != "" {
@@ -438,7 +445,7 @@ func printInspectService(out io.Writer, label string, state inspectServiceState,
 	if value := strings.TrimSpace(state.FragmentPath); value != "" {
 		parts = append(parts, "path="+value)
 	}
-	fmt.Fprintf(out, "- %s: %s\n", label, strings.Join(parts, " "))
+	return strings.Join(parts, " ")
 }
 
 func formatRemoteRuntimeConfigSummary(cfg *runtimeinstall.RuntimeConfig) string {

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -52,6 +52,7 @@ func newRootCommand(app *App) *cobra.Command {
 	rootCmd.AddCommand(newInspectCommand(app))
 	rootCmd.AddCommand(newStatusCommand(app))
 	rootCmd.AddCommand(newQuotaCommand(app))
+	rootCmd.AddCommand(newRuntimeCommand(app))
 	rootCmd.AddCommand(newSlackCommand(app))
 	rootCmd.AddCommand(newInitCommand(app))
 	rootCmd.AddCommand(newCreateCommand(app))

--- a/internal/app/runtime_service.go
+++ b/internal/app/runtime_service.go
@@ -1,0 +1,197 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"agenthub/internal/config"
+	"agenthub/internal/host"
+)
+
+type runtimeServiceOptions struct {
+	ConfigPath string
+	Target     string
+	SSHUser    string
+	SSHKey     string
+	SSHPort    int
+	Action     string
+}
+
+type runtimeServiceResult struct {
+	AgentName      string
+	ResolvedTarget string
+	Action         string
+	Changed        bool
+	Message        string
+	Service        inspectServiceState
+}
+
+func newRuntimeCommand(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "runtime",
+		Short:   "Run deployed runtime service commands",
+		GroupID: "runtime",
+	}
+	cmd.AddCommand(newRuntimeStartCommand(app))
+	return cmd
+}
+
+func newRuntimeStartCommand(app *App) *cobra.Command {
+	var target string
+	var sshUser string
+	var sshKey string
+	var sshPort int
+
+	cmd := &cobra.Command{
+		Use:          "start",
+		Short:        "Start the runtime service for a deployed agent",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(app.opts.ConfigPath) == "" {
+				return errors.New("config file is required: pass --config <path>")
+			}
+
+			cfg, err := config.Load(app.opts.ConfigPath)
+			if err != nil {
+				return err
+			}
+			if err := config.Validate(cfg); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "starting runtime service...")
+			result, err := runRuntimeServiceWorkflow(cmd.Context(), app.opts.Profile, cfg, runtimeServiceOptions{
+				ConfigPath: app.opts.ConfigPath,
+				Target:     target,
+				SSHUser:    sshUser,
+				SSHKey:     sshKey,
+				SSHPort:    sshPort,
+				Action:     "start",
+			})
+			printRuntimeServiceResult(cmd.OutOrStdout(), result)
+			if err != nil {
+				return wrapUserFacingError(
+					"runtime start failed",
+					err,
+					"the target host is unreachable, the runtime service is missing, or systemd could not start the unit",
+					"confirm the host is reachable over SSH and rerun "+commandRef(cmd.OutOrStdout(), "agenthub", "runtime", "start", "--config", app.opts.ConfigPath),
+					"run "+commandRef(cmd.OutOrStdout(), "agenthub", "inspect", agentNameFromConfigPath(app.opts.ConfigPath))+" after fixing the host state",
+				)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&target, "target", "", "SSH target host or EC2 instance id; defaults to infra.instance_id")
+	cmd.Flags().StringVar(&sshUser, "ssh-user", "", "SSH username for the target host")
+	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key")
+	cmd.Flags().IntVar(&sshPort, "ssh-port", 22, "SSH port")
+	return cmd
+}
+
+func runRuntimeServiceWorkflow(ctx context.Context, profile string, cfg *config.Config, opts runtimeServiceOptions) (runtimeServiceResult, error) {
+	if cfg == nil {
+		return runtimeServiceResult{}, errors.New("config is required")
+	}
+
+	action := strings.ToLower(strings.TrimSpace(opts.Action))
+	if action == "" {
+		action = "start"
+	}
+	if action != "start" {
+		return runtimeServiceResult{}, fmt.Errorf("unsupported runtime service action %q", action)
+	}
+
+	targetValue := strings.TrimSpace(opts.Target)
+	if targetValue == "" {
+		targetValue = strings.TrimSpace(cfg.Infra.InstanceID)
+	}
+	if targetValue == "" {
+		return runtimeServiceResult{}, errors.New("target is required: pass --target or run agenthub create first so infra.instance_id is recorded")
+	}
+
+	agentName := agentNameFromConfigPath(opts.ConfigPath)
+	if agentName == "" {
+		agentName = "default"
+	}
+
+	resolvedTarget, err := resolveHostTarget(ctx, profile, cfg, targetValue)
+	if err != nil {
+		return runtimeServiceResult{}, err
+	}
+	user, keyPath, err := resolveInstallSSH(cfg, opts.SSHUser, opts.SSHKey)
+	if err != nil {
+		return runtimeServiceResult{}, err
+	}
+
+	exec := newSSHExecutor(host.SSHConfig{
+		Host:           resolvedTarget,
+		Port:           opts.SSHPort,
+		User:           user,
+		IdentityFile:   keyPath,
+		ConnectTimeout: 15 * time.Second,
+	})
+	if err := waitForSSHReady(ctx, exec, resolvedTarget); err != nil {
+		return runtimeServiceResult{}, err
+	}
+
+	result := runtimeServiceResult{
+		AgentName:      agentName,
+		ResolvedTarget: resolvedTarget,
+		Action:         action,
+	}
+
+	state, err := inspectServiceUnit(ctx, exec, "agenthub.service")
+	if err != nil {
+		return result, fmt.Errorf("inspect runtime service: %w", err)
+	}
+	if !state.Installed {
+		return result, errors.New("runtime service: agenthub.service is not installed on the target host")
+	}
+	if strings.EqualFold(strings.TrimSpace(state.ActiveState), "active") {
+		result.Service = state
+		result.Message = "runtime service is already running"
+		return result, nil
+	}
+
+	commandResult, err := exec.Run(ctx, "sudo", "systemctl", action, "agenthub.service")
+	if err != nil {
+		msg := strings.TrimSpace(firstNonEmpty(commandResult.Stderr, commandResult.Stdout))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return result, fmt.Errorf("start runtime service: %s", msg)
+	}
+
+	state, err = inspectServiceUnit(ctx, exec, "agenthub.service")
+	if err != nil {
+		return result, fmt.Errorf("inspect runtime service after start: %w", err)
+	}
+	result.Service = state
+	if !strings.EqualFold(strings.TrimSpace(state.ActiveState), "active") {
+		return result, fmt.Errorf("runtime service did not reach active state after start: %s", formatInspectServiceSummary(state))
+	}
+
+	result.Changed = true
+	result.Message = "runtime service started"
+	return result, nil
+}
+
+func printRuntimeServiceResult(out io.Writer, result runtimeServiceResult) {
+	fmt.Fprintf(out, "agent: %s\n", result.AgentName)
+	if strings.TrimSpace(result.ResolvedTarget) != "" {
+		fmt.Fprintf(out, "target: %s\n", result.ResolvedTarget)
+	}
+	if strings.TrimSpace(result.Message) != "" {
+		fmt.Fprintf(out, "result: %s\n", result.Message)
+	}
+	if summary := formatInspectServiceSummary(result.Service); summary != "" {
+		fmt.Fprintf(out, "runtime service: %s\n", summary)
+	}
+}

--- a/internal/app/runtime_service_test.go
+++ b/internal/app/runtime_service_test.go
@@ -1,0 +1,317 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"agenthub/internal/host"
+	"agenthub/internal/provider"
+)
+
+func TestRuntimeStartCommandStartsInactiveService(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var startCalls int
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					if inspectCalls == 1 {
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=inactive\nSubState=dead\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					}
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl start agenthub.service":
+					startCalls++
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runRuntimeStartCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if startCalls != 1 {
+		t.Fatalf("startCalls = %d, want 1", startCalls)
+	}
+	for _, fragment := range []string{
+		"starting runtime service...",
+		"agent: alpha",
+		"target: 203.0.113.10",
+		"result: runtime service started",
+		"runtime service: agenthub.service active=active sub=running enabled=enabled path=/etc/systemd/system/agenthub.service",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Fatalf("stdout = %q, want %q", stdout, fragment)
+		}
+	}
+}
+
+func TestRuntimeStartCommandReportsNoOpWhenServiceAlreadyRunning(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var startCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl start agenthub.service":
+					startCalls++
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runRuntimeStartCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0", startCalls)
+	}
+	if !strings.Contains(stdout, "result: runtime service is already running") {
+		t.Fatalf("stdout = %q, want already-running message", stdout)
+	}
+}
+
+func TestRuntimeStartCommandFailsWhenServiceMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				if command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`) {
+					return host.CommandResult{Stdout: "installed=false\n"}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	_, err := runRuntimeStartCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if !strings.Contains(err.Error(), "agenthub.service is not installed") {
+		t.Fatalf("error = %q, want missing service error", err)
+	}
+}
+
+func TestRunRuntimeServiceWorkflowFailsWhenServiceDoesNotBecomeActive(t *testing.T) {
+	cfg := mustLoadConfigFromString(t, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+ssh:
+  user: ubuntu
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	cfg.SSH.PrivateKeyPath = keyPath
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					if inspectCalls == 1 {
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=inactive\nSubState=dead\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					}
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=failed\nSubState=failed\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl start agenthub.service":
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	_, err := runRuntimeServiceWorkflow(context.Background(), "", cfg, runtimeServiceOptions{
+		ConfigPath: filepath.Join("agents", "alpha", "config.yaml"),
+		Action:     "start",
+	})
+	if err == nil {
+		t.Fatal("runRuntimeServiceWorkflow() error = nil")
+	}
+	if !strings.Contains(err.Error(), "did not reach active state after start") {
+		t.Fatalf("error = %q, want post-start verification failure", err)
+	}
+}
+
+func runRuntimeStartCommand(t *testing.T, args []string) (string, error) {
+	t.Helper()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = append([]string{"agenthub", "runtime", "start"}, args...)
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	err := cmd.Execute()
+	return stdout.String(), err
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #79 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

• Implemented agenthub runtime start with the existing SSH/host-resolution flow and idempotent
  service handling. The new command lives under internal/app/runtime_service.go:35, is registered
  from internal/app/root.go:54, and reuses the same service-state formatting as internal/app/
  inspect.go:416. It loads --config, resolves --target or infra.instance_id, waits for SSH, inspects
  agenthub.service, no-ops if already active, runs sudo systemctl start agenthub.service otherwise,
  and verifies the unit becomes active afterward.

  I added coverage in internal/app/runtime_service_test.go:16 for start success, already-running no-
  op, missing unit failure, and post-start verification failure, and documented the new command in
  doc/cli-usage.md:28.

<!-- close -->
