### PR TITLE
stop command

### DIFF
--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -37,6 +37,12 @@ Start the runtime service for one deployed agent:
 agenthub runtime start --config agenthub.yaml
 ```
 
+Stop the runtime service for one deployed agent:
+
+```bash
+agenthub runtime stop --config agenthub.yaml
+```
+
 Show merged agent config status under `agents/`:
 
 ```bash

--- a/internal/app/runtime_service.go
+++ b/internal/app/runtime_service.go
@@ -39,6 +39,7 @@ func newRuntimeCommand(app *App) *cobra.Command {
 		GroupID: "runtime",
 	}
 	cmd.AddCommand(newRuntimeStartCommand(app))
+	cmd.AddCommand(newRuntimeStopCommand(app))
 	return cmd
 }
 
@@ -95,6 +96,59 @@ func newRuntimeStartCommand(app *App) *cobra.Command {
 	return cmd
 }
 
+func newRuntimeStopCommand(app *App) *cobra.Command {
+	var target string
+	var sshUser string
+	var sshKey string
+	var sshPort int
+
+	cmd := &cobra.Command{
+		Use:          "stop",
+		Short:        "Stop the runtime service for a deployed agent",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(app.opts.ConfigPath) == "" {
+				return errors.New("config file is required: pass --config <path>")
+			}
+
+			cfg, err := config.Load(app.opts.ConfigPath)
+			if err != nil {
+				return err
+			}
+			if err := config.Validate(cfg); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "stopping runtime service...")
+			result, err := runRuntimeServiceWorkflow(cmd.Context(), app.opts.Profile, cfg, runtimeServiceOptions{
+				ConfigPath: app.opts.ConfigPath,
+				Target:     target,
+				SSHUser:    sshUser,
+				SSHKey:     sshKey,
+				SSHPort:    sshPort,
+				Action:     "stop",
+			})
+			printRuntimeServiceResult(cmd.OutOrStdout(), result)
+			if err != nil {
+				return wrapUserFacingError(
+					"runtime stop failed",
+					err,
+					"the target host is unreachable, the runtime service is missing, or systemd could not stop the unit",
+					"confirm the host is reachable over SSH and rerun "+commandRef(cmd.OutOrStdout(), "agenthub", "runtime", "stop", "--config", app.opts.ConfigPath),
+					"run "+commandRef(cmd.OutOrStdout(), "agenthub", "inspect", agentNameFromConfigPath(app.opts.ConfigPath))+" after fixing the host state",
+				)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&target, "target", "", "SSH target host or EC2 instance id; defaults to infra.instance_id")
+	cmd.Flags().StringVar(&sshUser, "ssh-user", "", "SSH username for the target host")
+	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key")
+	cmd.Flags().IntVar(&sshPort, "ssh-port", 22, "SSH port")
+	return cmd
+}
+
 func runRuntimeServiceWorkflow(ctx context.Context, profile string, cfg *config.Config, opts runtimeServiceOptions) (runtimeServiceResult, error) {
 	if cfg == nil {
 		return runtimeServiceResult{}, errors.New("config is required")
@@ -104,7 +158,7 @@ func runRuntimeServiceWorkflow(ctx context.Context, profile string, cfg *config.
 	if action == "" {
 		action = "start"
 	}
-	if action != "start" {
+	if action != "start" && action != "stop" {
 		return runtimeServiceResult{}, fmt.Errorf("unsupported runtime service action %q", action)
 	}
 
@@ -154,9 +208,9 @@ func runRuntimeServiceWorkflow(ctx context.Context, profile string, cfg *config.
 	if !state.Installed {
 		return result, errors.New("runtime service: agenthub.service is not installed on the target host")
 	}
-	if strings.EqualFold(strings.TrimSpace(state.ActiveState), "active") {
+	if runtimeServiceActionAlreadySatisfied(action, state) {
 		result.Service = state
-		result.Message = "runtime service is already running"
+		result.Message = runtimeServiceAlreadySatisfiedMessage(action)
 		return result, nil
 	}
 
@@ -166,21 +220,65 @@ func runRuntimeServiceWorkflow(ctx context.Context, profile string, cfg *config.
 		if msg == "" {
 			msg = err.Error()
 		}
-		return result, fmt.Errorf("start runtime service: %s", msg)
+		return result, fmt.Errorf("%s runtime service: %s", action, msg)
 	}
 
 	state, err = inspectServiceUnit(ctx, exec, "agenthub.service")
 	if err != nil {
-		return result, fmt.Errorf("inspect runtime service after start: %w", err)
+		return result, fmt.Errorf("inspect runtime service after %s: %w", action, err)
 	}
 	result.Service = state
-	if !strings.EqualFold(strings.TrimSpace(state.ActiveState), "active") {
-		return result, fmt.Errorf("runtime service did not reach active state after start: %s", formatInspectServiceSummary(state))
+	if !runtimeServiceActionReachedExpectedState(action, state) {
+		return result, fmt.Errorf("runtime service did not reach expected state after %s: %s", action, formatInspectServiceSummary(state))
 	}
 
 	result.Changed = true
-	result.Message = "runtime service started"
+	result.Message = runtimeServiceChangedMessage(action)
 	return result, nil
+}
+
+func runtimeServiceActionAlreadySatisfied(action string, state inspectServiceState) bool {
+	switch action {
+	case "start":
+		return strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
+	case "stop":
+		return !strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
+	default:
+		return false
+	}
+}
+
+func runtimeServiceAlreadySatisfiedMessage(action string) string {
+	switch action {
+	case "start":
+		return "runtime service is already running"
+	case "stop":
+		return "runtime service is already stopped"
+	default:
+		return ""
+	}
+}
+
+func runtimeServiceChangedMessage(action string) string {
+	switch action {
+	case "start":
+		return "runtime service started"
+	case "stop":
+		return "runtime service stopped"
+	default:
+		return ""
+	}
+}
+
+func runtimeServiceActionReachedExpectedState(action string, state inspectServiceState) bool {
+	switch action {
+	case "start":
+		return strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
+	case "stop":
+		return !strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
+	default:
+		return false
+	}
 }
 
 func printRuntimeServiceResult(out io.Writer, result runtimeServiceResult) {

--- a/internal/app/runtime_service_test.go
+++ b/internal/app/runtime_service_test.go
@@ -509,7 +509,7 @@ sandbox:
 	if err == nil {
 		t.Fatal("runRuntimeServiceWorkflow() error = nil")
 	}
-	if !strings.Contains(err.Error(), "did not reach active state after start") {
+	if !strings.Contains(err.Error(), "did not reach expected state after start") {
 		t.Fatalf("error = %q, want post-start verification failure", err)
 	}
 }

--- a/internal/app/runtime_service_test.go
+++ b/internal/app/runtime_service_test.go
@@ -166,6 +166,221 @@ sandbox:
 	}
 }
 
+func TestRuntimeStopCommandStopsActiveService(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var stopCalls int
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					if inspectCalls == 1 {
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					}
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=inactive\nSubState=dead\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl stop agenthub.service":
+					stopCalls++
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runRuntimeStopCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("stopCalls = %d, want 1", stopCalls)
+	}
+	for _, fragment := range []string{
+		"stopping runtime service...",
+		"agent: alpha",
+		"target: 203.0.113.10",
+		"result: runtime service stopped",
+		"runtime service: agenthub.service active=inactive sub=dead enabled=enabled path=/etc/systemd/system/agenthub.service",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Fatalf("stdout = %q, want %q", stdout, fragment)
+		}
+	}
+}
+
+func TestRuntimeStopCommandReportsNoOpWhenServiceAlreadyStopped(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var stopCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=inactive\nSubState=dead\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl stop agenthub.service":
+					stopCalls++
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runRuntimeStopCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if stopCalls != 0 {
+		t.Fatalf("stopCalls = %d, want 0", stopCalls)
+	}
+	if !strings.Contains(stdout, "result: runtime service is already stopped") {
+		t.Fatalf("stdout = %q, want already-stopped message", stdout)
+	}
+}
+
+func TestRuntimeStopCommandFailsWhenServiceMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				if command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`) {
+					return host.CommandResult{Stdout: "installed=false\n"}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	_, err := runRuntimeStopCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if !strings.Contains(err.Error(), "agenthub.service is not installed") {
+		t.Fatalf("error = %q, want missing service error", err)
+	}
+}
+
 func TestRuntimeStartCommandFailsWhenServiceMissing(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
@@ -299,12 +514,99 @@ sandbox:
 	}
 }
 
+func TestRunRuntimeServiceWorkflowFailsWhenServiceDoesNotStop(t *testing.T) {
+	cfg := mustLoadConfigFromString(t, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+ssh:
+  user: ubuntu
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	cfg.SSH.PrivateKeyPath = keyPath
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					if inspectCalls == 1 {
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					}
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl stop agenthub.service":
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	_, err := runRuntimeServiceWorkflow(context.Background(), "", cfg, runtimeServiceOptions{
+		ConfigPath: filepath.Join("agents", "alpha", "config.yaml"),
+		Action:     "stop",
+	})
+	if err == nil {
+		t.Fatal("runRuntimeServiceWorkflow() error = nil")
+	}
+	if !strings.Contains(err.Error(), "did not reach expected state after stop") {
+		t.Fatalf("error = %q, want post-stop verification failure", err)
+	}
+}
+
 func runRuntimeStartCommand(t *testing.T, args []string) (string, error) {
 	t.Helper()
 
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	os.Args = append([]string{"agenthub", "runtime", "start"}, args...)
+
+	return runRuntimeCommand(t)
+}
+
+func runRuntimeStopCommand(t *testing.T, args []string) (string, error) {
+	t.Helper()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = append([]string{"agenthub", "runtime", "stop"}, args...)
+
+	return runRuntimeCommand(t)
+}
+
+func runRuntimeCommand(t *testing.T) (string, error) {
+	t.Helper()
 
 	app := New()
 	cmd := newRootCommand(app)


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #80 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

 Implemented agenthub runtime stop with the same config, SSH, and result-printing flow as runtime
  start. The shared workflow in internal/app/runtime_service.go now supports both actions, treats
  stop as idempotent when the service is already non-active, and verifies the post-action service
  state before reporting success.

  I added stop-path coverage in internal/app/runtime_service_test.go for successful stop, already-
  stopped no-op, missing service, and post-stop verification failure. I also updated doc/cli-
  usage.md to document agenthub runtime stop --config agenthub.yaml.

  Verification: go test ./internal/app -run 'TestRuntime(Start|Stop)|
  TestRunRuntimeServiceWorkflowFailsWhenServiceDoes(NotBecomeActive|NotStop)' passed.

<!-- close -->
