### PR TITLE
restart command

### DIFF
--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -37,6 +37,12 @@ Start the runtime service for one deployed agent:
 agenthub runtime start --config agenthub.yaml
 ```
 
+Restart the runtime service for one deployed agent:
+
+```bash
+agenthub runtime restart --config agenthub.yaml
+```
+
 Stop the runtime service for one deployed agent:
 
 ```bash

--- a/internal/app/runtime_service.go
+++ b/internal/app/runtime_service.go
@@ -331,6 +331,7 @@ func runtimeServiceChangedMessage(action string) string {
 func runtimeServiceActionReachedExpectedState(action string, state inspectServiceState) bool {
 	switch action {
 	case "start":
+		fallthrough
 	case "restart":
 		return strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
 	case "stop":

--- a/internal/app/runtime_service.go
+++ b/internal/app/runtime_service.go
@@ -39,6 +39,7 @@ func newRuntimeCommand(app *App) *cobra.Command {
 		GroupID: "runtime",
 	}
 	cmd.AddCommand(newRuntimeStartCommand(app))
+	cmd.AddCommand(newRuntimeRestartCommand(app))
 	cmd.AddCommand(newRuntimeStopCommand(app))
 	return cmd
 }
@@ -149,6 +150,59 @@ func newRuntimeStopCommand(app *App) *cobra.Command {
 	return cmd
 }
 
+func newRuntimeRestartCommand(app *App) *cobra.Command {
+	var target string
+	var sshUser string
+	var sshKey string
+	var sshPort int
+
+	cmd := &cobra.Command{
+		Use:          "restart",
+		Short:        "Restart the runtime service for a deployed agent",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(app.opts.ConfigPath) == "" {
+				return errors.New("config file is required: pass --config <path>")
+			}
+
+			cfg, err := config.Load(app.opts.ConfigPath)
+			if err != nil {
+				return err
+			}
+			if err := config.Validate(cfg); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "restarting runtime service...")
+			result, err := runRuntimeServiceWorkflow(cmd.Context(), app.opts.Profile, cfg, runtimeServiceOptions{
+				ConfigPath: app.opts.ConfigPath,
+				Target:     target,
+				SSHUser:    sshUser,
+				SSHKey:     sshKey,
+				SSHPort:    sshPort,
+				Action:     "restart",
+			})
+			printRuntimeServiceResult(cmd.OutOrStdout(), result)
+			if err != nil {
+				return wrapUserFacingError(
+					"runtime restart failed",
+					err,
+					"the target host is unreachable, the runtime service is missing, or systemd could not restart the unit",
+					"confirm the host is reachable over SSH and rerun "+commandRef(cmd.OutOrStdout(), "agenthub", "runtime", "restart", "--config", app.opts.ConfigPath),
+					"run "+commandRef(cmd.OutOrStdout(), "agenthub", "inspect", agentNameFromConfigPath(app.opts.ConfigPath))+" after fixing the host state",
+				)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&target, "target", "", "SSH target host or EC2 instance id; defaults to infra.instance_id")
+	cmd.Flags().StringVar(&sshUser, "ssh-user", "", "SSH username for the target host")
+	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key")
+	cmd.Flags().IntVar(&sshPort, "ssh-port", 22, "SSH port")
+	return cmd
+}
+
 func runRuntimeServiceWorkflow(ctx context.Context, profile string, cfg *config.Config, opts runtimeServiceOptions) (runtimeServiceResult, error) {
 	if cfg == nil {
 		return runtimeServiceResult{}, errors.New("config is required")
@@ -158,7 +212,7 @@ func runRuntimeServiceWorkflow(ctx context.Context, profile string, cfg *config.
 	if action == "" {
 		action = "start"
 	}
-	if action != "start" && action != "stop" {
+	if action != "start" && action != "stop" && action != "restart" {
 		return runtimeServiceResult{}, fmt.Errorf("unsupported runtime service action %q", action)
 	}
 
@@ -243,6 +297,8 @@ func runtimeServiceActionAlreadySatisfied(action string, state inspectServiceSta
 		return strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
 	case "stop":
 		return !strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
+	case "restart":
+		return false
 	default:
 		return false
 	}
@@ -263,6 +319,8 @@ func runtimeServiceChangedMessage(action string) string {
 	switch action {
 	case "start":
 		return "runtime service started"
+	case "restart":
+		return "runtime service restarted"
 	case "stop":
 		return "runtime service stopped"
 	default:
@@ -273,6 +331,7 @@ func runtimeServiceChangedMessage(action string) string {
 func runtimeServiceActionReachedExpectedState(action string, state inspectServiceState) bool {
 	switch action {
 	case "start":
+	case "restart":
 		return strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
 	case "stop":
 		return !strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")

--- a/internal/app/runtime_service_test.go
+++ b/internal/app/runtime_service_test.go
@@ -166,6 +166,167 @@ sandbox:
 	}
 }
 
+func TestRuntimeRestartCommandRestartsActiveService(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var restartCalls int
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl restart agenthub.service":
+					restartCalls++
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runRuntimeRestartCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if restartCalls != 1 {
+		t.Fatalf("restartCalls = %d, want 1", restartCalls)
+	}
+	if inspectCalls != 2 {
+		t.Fatalf("inspectCalls = %d, want 2", inspectCalls)
+	}
+	for _, fragment := range []string{
+		"restarting runtime service...",
+		"agent: alpha",
+		"target: 203.0.113.10",
+		"result: runtime service restarted",
+		"runtime service: agenthub.service active=active sub=running enabled=enabled path=/etc/systemd/system/agenthub.service",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Fatalf("stdout = %q, want %q", stdout, fragment)
+		}
+	}
+}
+
+func TestRuntimeRestartCommandStartsStoppedService(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var restartCalls int
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					if inspectCalls == 1 {
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=inactive\nSubState=dead\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					}
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl restart agenthub.service":
+					restartCalls++
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runRuntimeRestartCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if restartCalls != 1 {
+		t.Fatalf("restartCalls = %d, want 1", restartCalls)
+	}
+	if inspectCalls != 2 {
+		t.Fatalf("inspectCalls = %d, want 2", inspectCalls)
+	}
+	if !strings.Contains(stdout, "result: runtime service restarted") {
+		t.Fatalf("stdout = %q, want restarted message", stdout)
+	}
+}
+
 func TestRuntimeStopCommandStopsActiveService(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
@@ -443,6 +604,68 @@ sandbox:
 	}
 }
 
+func TestRuntimeRestartCommandFailsWhenServiceMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				if command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`) {
+					return host.CommandResult{Stdout: "installed=false\n"}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	_, err := runRuntimeRestartCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if !strings.Contains(err.Error(), "agenthub.service is not installed") {
+		t.Fatalf("error = %q, want missing service error", err)
+	}
+}
+
 func TestRunRuntimeServiceWorkflowFailsWhenServiceDoesNotBecomeActive(t *testing.T) {
 	cfg := mustLoadConfigFromString(t, `
 platform:
@@ -585,12 +808,93 @@ sandbox:
 	}
 }
 
+func TestRunRuntimeServiceWorkflowFailsWhenServiceDoesNotBecomeActiveAfterRestart(t *testing.T) {
+	cfg := mustLoadConfigFromString(t, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+ssh:
+  user: ubuntu
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	cfg.SSH.PrivateKeyPath = keyPath
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					if inspectCalls == 1 {
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=inactive\nSubState=dead\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					}
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=failed\nSubState=failed\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl restart agenthub.service":
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	_, err := runRuntimeServiceWorkflow(context.Background(), "", cfg, runtimeServiceOptions{
+		ConfigPath: filepath.Join("agents", "alpha", "config.yaml"),
+		Action:     "restart",
+	})
+	if err == nil {
+		t.Fatal("runRuntimeServiceWorkflow() error = nil")
+	}
+	if !strings.Contains(err.Error(), "did not reach expected state after restart") {
+		t.Fatalf("error = %q, want post-restart verification failure", err)
+	}
+}
+
 func runRuntimeStartCommand(t *testing.T, args []string) (string, error) {
 	t.Helper()
 
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	os.Args = append([]string{"agenthub", "runtime", "start"}, args...)
+
+	return runRuntimeCommand(t)
+}
+
+func runRuntimeRestartCommand(t *testing.T, args []string) (string, error) {
+	t.Helper()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = append([]string{"agenthub", "runtime", "restart"}, args...)
 
 	return runRuntimeCommand(t)
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #81 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

• Added agenthub runtime restart and wired it through the existing runtime-service workflow. The new
  command lives alongside start and stop in internal/app/runtime_service.go:35, uses the same
  config/SSH targeting, and treats restart like systemctl restart: it always runs the restart and
  only succeeds if the service is active afterward. The shared action handling was extended to
  accept restart and return the new success text runtime service restarted in internal/app/
  runtime_service.go:153 and internal/app/runtime_service.go:211.

  Test coverage now includes restart on an active service, restart from a stopped state, missing
  service failure, and post-restart verification failure in internal/app/
  runtime_service_test.go:169. I also documented the new CLI command in doc/cli-usage.md:40.

  Verification: go test ./internal/app/... passed.

<!-- close -->
