### PR TITLE
output formatting

### DIFF
--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -67,6 +67,12 @@ Inspect one deployed agent in detail:
 agenthub inspect alpha --ssh-key ~/.ssh/id_ed25519
 ```
 
+Show the same inspection report as structured JSON for automation:
+
+```bash
+agenthub inspect alpha --ssh-key ~/.ssh/id_ed25519 --output json
+```
+
 `agenthub inspect` reads the merged local config for the selected agent, resolves the recorded deployment target, and probes the remote runtime state over SSH.
 
 ## Infrastructure Teardown

--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -55,6 +55,12 @@ Show merged agent config status under `agents/`:
 agenthub status
 ```
 
+Show the same status as structured JSON for automation:
+
+```bash
+agenthub status --output json
+```
+
 Inspect one deployed agent in detail:
 
 ```bash

--- a/internal/app/inspect.go
+++ b/internal/app/inspect.go
@@ -43,8 +43,10 @@ type inspectReport struct {
 	RuntimeService    inspectServiceState
 	RuntimeServiceErr error
 	SlackService      inspectServiceState
+	SlackServiceErr   error
 	Health            map[string]any
 	HealthErr         error
+	StatusPayload     map[string]any
 	Status            *runtimeStatusResponse
 	StatusErr         error
 	Warnings          []string
@@ -60,6 +62,84 @@ type inspectServiceState struct {
 	FragmentPath  string
 }
 
+type inspectOutputFormat string
+
+const (
+	inspectOutputText inspectOutputFormat = "text"
+	inspectOutputJSON inspectOutputFormat = "json"
+)
+
+type inspectJSONResponse struct {
+	Agent            string                      `json:"agent"`
+	Path             string                      `json:"path,omitempty"`
+	Files            []string                    `json:"files,omitempty"`
+	LocalConfig      *inspectJSONLocalConfig     `json:"local_config,omitempty"`
+	Cloud            inspectJSONCloudState       `json:"cloud"`
+	RemoteDeployment inspectJSONRemoteDeployment `json:"remote_deployment"`
+	RuntimeState     inspectJSONRuntimeState     `json:"runtime_state"`
+	Warnings         []string                    `json:"warnings,omitempty"`
+}
+
+type inspectJSONLocalConfig struct {
+	Config          *statusJSONConfig `json:"config,omitempty"`
+	InfraInstanceID string            `json:"infra_instance_id,omitempty"`
+	SlackRuntimeURL string            `json:"slack_runtime_url,omitempty"`
+}
+
+type inspectJSONCloudState struct {
+	State    string                  `json:"state"`
+	Error    string                  `json:"error,omitempty"`
+	Instance *statusJSONLiveInstance `json:"instance,omitempty"`
+}
+
+type inspectJSONRemoteDeployment struct {
+	SSHTarget          string                    `json:"ssh_target,omitempty"`
+	RuntimeConfigPath  string                    `json:"runtime_config_path,omitempty"`
+	RuntimeConfig      *inspectJSONRuntimeConfig `json:"runtime_config,omitempty"`
+	RuntimeService     inspectJSONServiceState   `json:"runtime_service"`
+	IntegrationService inspectJSONServiceState   `json:"integration_service"`
+}
+
+type inspectJSONRuntimeConfig struct {
+	Provider    string              `json:"provider,omitempty"`
+	NIMEndpoint string              `json:"nim_endpoint,omitempty"`
+	Model       string              `json:"model,omitempty"`
+	Port        int                 `json:"port,omitempty"`
+	Region      string              `json:"region,omitempty"`
+	UseNemoClaw bool                `json:"use_nemoclaw"`
+	GitHub      *statusJSONGitHub   `json:"github,omitempty"`
+	Sandbox     *inspectJSONSandbox `json:"sandbox,omitempty"`
+}
+
+type inspectJSONSandbox struct {
+	Enabled         bool     `json:"enabled"`
+	NetworkMode     string   `json:"network_mode,omitempty"`
+	FilesystemAllow []string `json:"filesystem_allow,omitempty"`
+}
+
+type inspectJSONServiceState struct {
+	Unit          string `json:"unit,omitempty"`
+	Installed     bool   `json:"installed"`
+	LoadState     string `json:"load_state,omitempty"`
+	ActiveState   string `json:"active_state,omitempty"`
+	SubState      string `json:"sub_state,omitempty"`
+	UnitFileState string `json:"unit_file_state,omitempty"`
+	FragmentPath  string `json:"fragment_path,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+type inspectJSONRuntimeState struct {
+	Health inspectJSONEndpointState `json:"health"`
+	Status inspectJSONEndpointState `json:"status"`
+}
+
+type inspectJSONEndpointState struct {
+	Available bool                   `json:"available"`
+	Error     string                 `json:"error,omitempty"`
+	Payload   map[string]any         `json:"payload,omitempty"`
+	Summary   *runtimeStatusResponse `json:"summary,omitempty"`
+}
+
 func newInspectCommand(app *App) *cobra.Command {
 	var agentsDir string
 	var target string
@@ -67,14 +147,20 @@ func newInspectCommand(app *App) *cobra.Command {
 	var sshKey string
 	var sshPort int
 	var runtimeConfigPath string
+	var output string
 
 	cmd := &cobra.Command{
-		Use:          "inspect <agent>",
-		Short:        "Inspect one agent in detail",
-		GroupID:      "inspect",
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Use:           "inspect <agent>",
+		Short:         "Inspect one agent in detail",
+		GroupID:       "inspect",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat, parseErr := parseInspectOutputFormat(output)
+			if parseErr != nil {
+				return parseErr
+			}
 			report, err := runInspectWorkflow(cmd.Context(), app.opts.Profile, inspectOptions{
 				AgentName:         strings.TrimSpace(args[0]),
 				AgentsDir:         agentsDir,
@@ -84,7 +170,14 @@ func newInspectCommand(app *App) *cobra.Command {
 				SSHPort:           sshPort,
 				RuntimeConfigPath: runtimeConfigPath,
 			})
-			printInspectReport(cmd.OutOrStdout(), report)
+			switch outputFormat {
+			case inspectOutputJSON:
+				if encodeErr := json.NewEncoder(cmd.OutOrStdout()).Encode(buildInspectJSONResponse(report)); encodeErr != nil {
+					return encodeErr
+				}
+			default:
+				printInspectReport(cmd.OutOrStdout(), report)
+			}
 			if err != nil {
 				return wrapUserFacingError(
 					"inspect failed",
@@ -103,7 +196,19 @@ func newInspectCommand(app *App) *cobra.Command {
 	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key")
 	cmd.Flags().IntVar(&sshPort, "ssh-port", 22, "SSH port")
 	cmd.Flags().StringVar(&runtimeConfigPath, "runtime-config", "/opt/agenthub/runtime.yaml", "path to the runtime config on the target host")
+	cmd.Flags().StringVar(&output, "output", string(inspectOutputText), "output format: text or json")
 	return cmd
+}
+
+func parseInspectOutputFormat(value string) (inspectOutputFormat, error) {
+	switch inspectOutputFormat(strings.ToLower(strings.TrimSpace(value))) {
+	case "", inspectOutputText:
+		return inspectOutputText, nil
+	case inspectOutputJSON:
+		return inspectOutputJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported output format %q: expected text or json", value)
+	}
 }
 
 func runInspectWorkflow(ctx context.Context, profile string, opts inspectOptions) (inspectReport, error) {
@@ -165,6 +270,7 @@ func runInspectWorkflow(ctx context.Context, profile string, opts inspectOptions
 
 	report.SlackService, err = inspectServiceUnit(ctx, exec, slackServiceNameForAgent(report.AgentName)+".service")
 	if err != nil {
+		report.SlackServiceErr = err
 		report.Warnings = append(report.Warnings, fmt.Sprintf("integration service probe failed: %v", err))
 	}
 
@@ -180,6 +286,7 @@ func runInspectWorkflow(ctx context.Context, profile string, opts inspectOptions
 		report.StatusErr = statusErr
 		errs = append(errs, fmt.Errorf("runtime status: %w", statusErr))
 	} else {
+		report.StatusPayload = cloneJSONMap(statusPayload)
 		var decoded runtimeStatusResponse
 		data, marshalErr := json.Marshal(statusPayload)
 		if marshalErr != nil {
@@ -392,7 +499,7 @@ func printInspectReport(out io.Writer, report inspectReport) {
 		fmt.Fprintf(out, "- remote runtime config: %s\n", formatRemoteRuntimeConfigSummary(report.RuntimeConfig))
 	}
 	printInspectService(out, "runtime service", report.RuntimeService, report.RuntimeServiceErr)
-	printInspectService(out, "integration service", report.SlackService, nil)
+	printInspectService(out, "integration service", report.SlackService, report.SlackServiceErr)
 
 	fmt.Fprintln(out, "runtime state")
 	if report.HealthErr != nil {
@@ -411,6 +518,112 @@ func printInspectReport(out io.Writer, report inspectReport) {
 	for _, warning := range report.Warnings {
 		fmt.Fprintf(out, "warning: %s\n", warning)
 	}
+}
+
+func buildInspectJSONResponse(report inspectReport) inspectJSONResponse {
+	return inspectJSONResponse{
+		Agent: report.AgentName,
+		Path:  report.Path,
+		Files: append([]string(nil), report.Files...),
+		LocalConfig: &inspectJSONLocalConfig{
+			Config:          buildStatusJSONConfig(report.Config),
+			InfraInstanceID: strings.TrimSpace(report.Config.Infra.InstanceID),
+			SlackRuntimeURL: strings.TrimSpace(report.Config.Slack.RuntimeURL),
+		},
+		Cloud: inspectJSONCloudState{
+			State:    buildStatusJSONLiveStatus(agentStatusEntry{Config: report.Config, Live: agentLiveStatus{Instance: report.Cloud, Err: report.CloudErr}}).State,
+			Error:    buildStatusJSONLiveStatus(agentStatusEntry{Config: report.Config, Live: agentLiveStatus{Instance: report.Cloud, Err: report.CloudErr}}).Error,
+			Instance: buildStatusJSONLiveStatus(agentStatusEntry{Config: report.Config, Live: agentLiveStatus{Instance: report.Cloud, Err: report.CloudErr}}).Instance,
+		},
+		RemoteDeployment: inspectJSONRemoteDeployment{
+			SSHTarget:          strings.TrimSpace(report.ResolvedTarget),
+			RuntimeConfigPath:  strings.TrimSpace(report.RuntimeConfigPath),
+			RuntimeConfig:      buildInspectJSONRuntimeConfig(report.RuntimeConfig),
+			RuntimeService:     buildInspectJSONServiceState(report.RuntimeService, report.RuntimeServiceErr),
+			IntegrationService: buildInspectJSONServiceState(report.SlackService, report.SlackServiceErr),
+		},
+		RuntimeState: inspectJSONRuntimeState{
+			Health: buildInspectJSONHealthState(report),
+			Status: buildInspectJSONStatusState(report),
+		},
+		Warnings: append([]string(nil), report.Warnings...),
+	}
+}
+
+func buildInspectJSONRuntimeConfig(cfg *runtimeinstall.RuntimeConfig) *inspectJSONRuntimeConfig {
+	if cfg == nil {
+		return nil
+	}
+	out := &inspectJSONRuntimeConfig{
+		Provider:    strings.TrimSpace(cfg.Provider),
+		NIMEndpoint: strings.TrimSpace(cfg.NIMEndpoint),
+		Model:       strings.TrimSpace(cfg.Model),
+		Port:        cfg.Port,
+		Region:      strings.TrimSpace(cfg.Region),
+		UseNemoClaw: cfg.UseNemoClaw,
+		Sandbox: &inspectJSONSandbox{
+			Enabled:         cfg.Sandbox.Enabled,
+			NetworkMode:     strings.TrimSpace(cfg.Sandbox.NetworkMode),
+			FilesystemAllow: append([]string(nil), cfg.Sandbox.FilesystemAllow...),
+		},
+	}
+	if github := buildStatusJSONGitHub(cfg.GitHub); github != nil {
+		out.GitHub = github
+	}
+	return out
+}
+
+func buildInspectJSONServiceState(state inspectServiceState, err error) inspectJSONServiceState {
+	out := inspectJSONServiceState{
+		Unit:          strings.TrimSpace(state.Unit),
+		Installed:     state.Installed,
+		LoadState:     strings.TrimSpace(state.LoadState),
+		ActiveState:   strings.TrimSpace(state.ActiveState),
+		SubState:      strings.TrimSpace(state.SubState),
+		UnitFileState: strings.TrimSpace(state.UnitFileState),
+		FragmentPath:  strings.TrimSpace(state.FragmentPath),
+	}
+	if err != nil {
+		out.Error = err.Error()
+	}
+	return out
+}
+
+func buildInspectJSONHealthState(report inspectReport) inspectJSONEndpointState {
+	out := inspectJSONEndpointState{
+		Available: report.HealthErr == nil && len(report.Health) > 0,
+		Payload:   cloneJSONMap(report.Health),
+	}
+	if report.HealthErr != nil {
+		out.Error = report.HealthErr.Error()
+	}
+	return out
+}
+
+func buildInspectJSONStatusState(report inspectReport) inspectJSONEndpointState {
+	out := inspectJSONEndpointState{
+		Available: report.StatusErr == nil && len(report.StatusPayload) > 0,
+		Payload:   cloneJSONMap(report.StatusPayload),
+	}
+	if report.StatusErr != nil {
+		out.Error = report.StatusErr.Error()
+	}
+	if report.Status != nil {
+		summary := *report.Status
+		out.Summary = &summary
+	}
+	return out
+}
+
+func cloneJSONMap(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }
 
 func printInspectService(out io.Writer, label string, state inspectServiceState, err error) {

--- a/internal/app/inspect_test.go
+++ b/internal/app/inspect_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -222,6 +223,256 @@ sandbox:
 		if !strings.Contains(stdout, fragment) {
 			t.Fatalf("stdout = %q, want %q", stdout, fragment)
 		}
+	}
+}
+
+func TestInspectCommandOutputsJSON(t *testing.T) {
+	agentsDir := filepath.Join(t.TempDir(), "agents")
+	agentDir := filepath.Join(agentsDir, "alpha")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agent) error = %v", err)
+	}
+
+	writeConfig(t, filepath.Join(agentDir, "config.yaml"), `
+platform:
+  name: aws
+compute:
+  class: gpu
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+  provider: codex
+  port: 9090
+slack:
+  runtime_url: http://203.0.113.10:9090
+github:
+  auth_mode: user
+  token_secret_arn: arn:aws:secretsmanager:us-west-2:123456789012:secret:agenthub/github-token
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: true
+  network_mode: public
+  use_nemoclaw: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case key == "cat /opt/agenthub/runtime.yaml":
+					return host.CommandResult{Stdout: strings.TrimSpace(`
+provider: codex
+nim_endpoint: http://localhost:11434
+model: llama3.2
+port: 9090
+region: us-west-2
+use_nemoclaw: true
+github:
+  auth_mode: user
+  token_secret_arn: arn:aws:secretsmanager:us-west-2:123456789012:secret:agenthub/github-token
+sandbox:
+  enabled: true
+  network_mode: public
+  filesystem_allow:
+    - /tmp
+`)}, nil
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc":
+					script := args[1]
+					switch {
+					case strings.Contains(script, `unit="agenthub.service"`):
+						return host.CommandResult{Stdout: strings.Join([]string{
+							"installed=true",
+							"LoadState=loaded",
+							"ActiveState=active",
+							"SubState=running",
+							"UnitFileState=enabled",
+							"FragmentPath=/etc/systemd/system/agenthub.service",
+						}, "\n")}, nil
+					case strings.Contains(script, `unit="agenthub-slack-alpha.service"`):
+						return host.CommandResult{Stdout: "installed=false\n"}, nil
+					case strings.Contains(script, "http://127.0.0.1:9090/healthz"):
+						return host.CommandResult{Stdout: `{"status":"ok","provider":"codex","model":"llama3.2","configured_port":9090,"workspace_root":"/opt/agenthub/workspace","runtime_config":"/opt/agenthub/runtime.yaml"}`}, nil
+					case strings.Contains(script, "http://127.0.0.1:9090/status"):
+						return host.CommandResult{Stdout: `{"status":"ok","active":true,"active_count":1,"active_agents":[{"id":"agent-1","task":"executing pwd"}]}`}, nil
+					}
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runInspectCommand(t, []string{"alpha", "--agents-dir", agentsDir, "--ssh-user", "ubuntu", "--ssh-key", keyPath, "--output", "json"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var payload inspectJSONResponse
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v, stdout = %q", err, stdout)
+	}
+	if payload.Agent != "alpha" {
+		t.Fatalf("agent = %q, want alpha", payload.Agent)
+	}
+	if payload.LocalConfig == nil || payload.LocalConfig.Config == nil || payload.LocalConfig.Config.Runtime == nil {
+		t.Fatalf("local_config = %#v, want structured config", payload.LocalConfig)
+	}
+	if payload.LocalConfig.InfraInstanceID != "i-0123456789abcdef0" {
+		t.Fatalf("infra_instance_id = %q, want populated value", payload.LocalConfig.InfraInstanceID)
+	}
+	if payload.Cloud.State != "available" || payload.Cloud.Instance == nil || payload.Cloud.Instance.ID != "i-0123456789abcdef0" {
+		t.Fatalf("cloud = %#v, want available instance", payload.Cloud)
+	}
+	if payload.RemoteDeployment.SSHTarget != "203.0.113.10" {
+		t.Fatalf("ssh_target = %q, want 203.0.113.10", payload.RemoteDeployment.SSHTarget)
+	}
+	if payload.RemoteDeployment.RuntimeConfig == nil || payload.RemoteDeployment.RuntimeConfig.UseNemoClaw != true || payload.RemoteDeployment.RuntimeConfig.Sandbox == nil || len(payload.RemoteDeployment.RuntimeConfig.Sandbox.FilesystemAllow) != 1 {
+		t.Fatalf("runtime_config = %#v, want structured remote runtime config", payload.RemoteDeployment.RuntimeConfig)
+	}
+	if payload.RemoteDeployment.RuntimeService.Unit != "agenthub.service" || !payload.RemoteDeployment.RuntimeService.Installed {
+		t.Fatalf("runtime_service = %#v, want installed runtime service", payload.RemoteDeployment.RuntimeService)
+	}
+	if payload.RemoteDeployment.IntegrationService.Unit != "agenthub-slack-alpha.service" || payload.RemoteDeployment.IntegrationService.Installed {
+		t.Fatalf("integration_service = %#v, want not installed integration service", payload.RemoteDeployment.IntegrationService)
+	}
+	if !payload.RuntimeState.Health.Available || payload.RuntimeState.Health.Payload["status"] != "ok" {
+		t.Fatalf("health = %#v, want available raw payload", payload.RuntimeState.Health)
+	}
+	if !payload.RuntimeState.Status.Available || payload.RuntimeState.Status.Payload["active_count"] != float64(1) || payload.RuntimeState.Status.Summary == nil || payload.RuntimeState.Status.Summary.ActiveCount != 1 {
+		t.Fatalf("status = %#v, want raw payload and summary", payload.RuntimeState.Status)
+	}
+}
+
+func TestInspectCommandOutputsJSONForPartialFailureAndReturnsError(t *testing.T) {
+	agentsDir := filepath.Join(t.TempDir(), "agents")
+	agentDir := filepath.Join(agentsDir, "alpha")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agent) error = %v", err)
+	}
+
+	writeConfig(t, filepath.Join(agentDir, "config.yaml"), `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case key == "cat /opt/agenthub/runtime.yaml":
+					return host.CommandResult{Stdout: "provider: ollama\nnim_endpoint: http://localhost:11434\nmodel: llama3.2\nport: 8080\nsandbox:\n  enabled: false\n"}, nil
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc":
+					script := args[1]
+					switch {
+					case strings.Contains(script, `unit="agenthub.service"`):
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=active\nSubState=running\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					case strings.Contains(script, `unit="agenthub-slack-alpha.service"`):
+						return host.CommandResult{Stderr: "permission denied"}, errors.New("permission denied")
+					case strings.Contains(script, "http://127.0.0.1:8080/healthz"):
+						return host.CommandResult{Stderr: "connection refused"}, errors.New("connection refused")
+					case strings.Contains(script, "http://127.0.0.1:8080/status"):
+						return host.CommandResult{Stdout: `{"status":"ok","active":false,"active_count":0}`}, nil
+					}
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runInspectCommand(t, []string{"alpha", "--agents-dir", agentsDir, "--ssh-user", "ubuntu", "--ssh-key", keyPath, "--output", "json"})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want partial remote failure")
+	}
+	if !strings.Contains(err.Error(), "runtime health") {
+		t.Fatalf("error = %q, want runtime health failure", err)
+	}
+
+	var payload inspectJSONResponse
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v, stdout = %q", err, stdout)
+	}
+	if payload.RuntimeState.Health.Available {
+		t.Fatalf("health.available = true, want false")
+	}
+	if !strings.Contains(payload.RuntimeState.Health.Error, "connection refused") {
+		t.Fatalf("health.error = %q, want connection refused", payload.RuntimeState.Health.Error)
+	}
+	if payload.RuntimeState.Status.Summary == nil || payload.RuntimeState.Status.Summary.ActiveCount != 0 {
+		t.Fatalf("status.summary = %#v, want active_count=0", payload.RuntimeState.Status.Summary)
+	}
+	if !strings.Contains(strings.Join(payload.Warnings, "\n"), "integration service probe failed") {
+		t.Fatalf("warnings = %#v, want integration service warning", payload.Warnings)
+	}
+	if !strings.Contains(payload.RemoteDeployment.IntegrationService.Error, "permission denied") {
+		t.Fatalf("integration_service.error = %q, want permission denied", payload.RemoteDeployment.IntegrationService.Error)
+	}
+}
+
+func TestInspectCommandRejectsUnsupportedOutputFormat(t *testing.T) {
+	stdout, err := runInspectCommand(t, []string{"alpha", "--output", "xml"})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unsupported output format error")
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty output", stdout)
+	}
+	if !strings.Contains(err.Error(), "unsupported output format") {
+		t.Fatalf("err = %q, want unsupported output format", err)
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -160,9 +160,11 @@ func newStatusCommand(app *App) *cobra.Command {
 	var output string
 
 	cmd := &cobra.Command{
-		Use:     "status",
-		Short:   "Show formatted agent configuration status",
-		GroupID: "runtime",
+		Use:           "status",
+		Short:         "Show formatted agent configuration status",
+		GroupID:       "runtime",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat, err := parseStatusOutputFormat(output)
 			if err != nil {

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -38,23 +39,163 @@ type agentLiveStatus struct {
 	Err      error
 }
 
+type statusOutputFormat string
+
+const (
+	statusOutputText statusOutputFormat = "text"
+	statusOutputJSON statusOutputFormat = "json"
+)
+
+type statusJSONResponse struct {
+	Root   string                 `json:"root"`
+	Agents []statusJSONAgentEntry `json:"agents"`
+}
+
+type statusJSONAgentEntry struct {
+	Name   string                 `json:"name"`
+	Path   string                 `json:"path"`
+	Files  []string               `json:"files,omitempty"`
+	Status string                 `json:"status"`
+	Error  string                 `json:"error,omitempty"`
+	Config *statusJSONConfig      `json:"config,omitempty"`
+	Live   statusJSONLiveStatus   `json:"live"`
+}
+
+type statusJSONConfig struct {
+	Platform *statusJSONNameField  `json:"platform,omitempty"`
+	Compute  *statusJSONClassField `json:"compute,omitempty"`
+	Region   *statusJSONNameField  `json:"region,omitempty"`
+	Instance *statusJSONInstance   `json:"instance,omitempty"`
+	Image    *statusJSONImage      `json:"image,omitempty"`
+	Runtime  *statusJSONRuntime    `json:"runtime,omitempty"`
+	Sandbox  *statusJSONSandbox    `json:"sandbox,omitempty"`
+	SSH      *statusJSONSSH        `json:"ssh,omitempty"`
+	GitHub   *statusJSONGitHub     `json:"github,omitempty"`
+	Infra    *statusJSONInfra      `json:"infra,omitempty"`
+}
+
+type statusJSONNameField struct {
+	Name string `json:"name"`
+}
+
+type statusJSONClassField struct {
+	Class string `json:"class"`
+}
+
+type statusJSONInstance struct {
+	Type        string `json:"type,omitempty"`
+	DiskSizeGB  int    `json:"disk_size_gb,omitempty"`
+	NetworkMode string `json:"network_mode,omitempty"`
+}
+
+type statusJSONImage struct {
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+type statusJSONRuntime struct {
+	Endpoint   string                `json:"endpoint,omitempty"`
+	Model      string                `json:"model,omitempty"`
+	Port       int                   `json:"port,omitempty"`
+	Provider   string                `json:"provider,omitempty"`
+	PublicCIDR string                `json:"public_cidr,omitempty"`
+	Codex      *statusJSONRuntimeCodex `json:"codex,omitempty"`
+}
+
+type statusJSONRuntimeCodex struct {
+	SecretID string `json:"secret_id,omitempty"`
+}
+
+type statusJSONSandbox struct {
+	Enabled         bool     `json:"enabled"`
+	NetworkMode     string   `json:"network_mode,omitempty"`
+	UseNemoClaw     bool     `json:"use_nemoclaw"`
+	FilesystemAllow []string `json:"filesystem_allow,omitempty"`
+}
+
+type statusJSONSSH struct {
+	KeyName              string `json:"key_name,omitempty"`
+	PrivateKeyPath       string `json:"private_key_path,omitempty"`
+	GitHubPrivateKeyPath string `json:"github_private_key_path,omitempty"`
+	CIDR                 string `json:"cidr,omitempty"`
+	User                 string `json:"user,omitempty"`
+}
+
+type statusJSONGitHub struct {
+	AuthMode            string `json:"auth_mode,omitempty"`
+	AppID               string `json:"app_id,omitempty"`
+	InstallationID      string `json:"installation_id,omitempty"`
+	PrivateKeySecretARN string `json:"private_key_secret_arn,omitempty"`
+	TokenSecretARN      string `json:"token_secret_arn,omitempty"`
+}
+
+type statusJSONInfra struct {
+	Backend     string `json:"backend,omitempty"`
+	ModuleDir   string `json:"module_dir,omitempty"`
+	AWSProfile  string `json:"aws_profile,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	InstanceID  string `json:"instance_id,omitempty"`
+}
+
+type statusJSONLiveStatus struct {
+	State    string                  `json:"state"`
+	Error    string                  `json:"error,omitempty"`
+	Instance *statusJSONLiveInstance `json:"instance,omitempty"`
+}
+
+type statusJSONLiveInstance struct {
+	ID               string `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	State            string `json:"state,omitempty"`
+	InstanceType     string `json:"instance_type,omitempty"`
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	PublicIP         string `json:"public_ip,omitempty"`
+	PrivateIP        string `json:"private_ip,omitempty"`
+	LaunchTime       string `json:"launch_time,omitempty"`
+	KeyName          string `json:"key_name,omitempty"`
+}
+
 func newStatusCommand(app *App) *cobra.Command {
 	var agentsDir string
+	var output string
 
 	cmd := &cobra.Command{
 		Use:     "status",
 		Short:   "Show formatted agent configuration status",
 		GroupID: "runtime",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat, err := parseStatusOutputFormat(output)
+			if err != nil {
+				return err
+			}
 			report, err := loadAgentStatusReport(agentsDir)
 			attachAgentLiveStatus(cmd.Context(), app.opts.Profile, &report)
-			printAgentStatusReport(cmd.OutOrStdout(), report)
+			switch outputFormat {
+			case statusOutputJSON:
+				if encodeErr := json.NewEncoder(cmd.OutOrStdout()).Encode(buildStatusJSONResponse(report)); encodeErr != nil {
+					return encodeErr
+				}
+			default:
+				printAgentStatusReport(cmd.OutOrStdout(), report)
+			}
 			return err
 		},
 	}
 
 	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
+	cmd.Flags().StringVar(&output, "output", string(statusOutputText), "output format: text or json")
 	return cmd
+}
+
+func parseStatusOutputFormat(value string) (statusOutputFormat, error) {
+	switch statusOutputFormat(strings.ToLower(strings.TrimSpace(value))) {
+	case "", statusOutputText:
+		return statusOutputText, nil
+	case statusOutputJSON:
+		return statusOutputJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported output format %q: expected text or json", value)
+	}
 }
 
 func loadAgentStatusReport(root string) (agentStatusReport, error) {
@@ -279,6 +420,184 @@ func printAgentStatusReport(out io.Writer, report agentStatusReport) {
 		for _, line := range formatAgentLiveSummary(agent) {
 			fmt.Fprintf(out, "  %s\n", line)
 		}
+	}
+}
+
+func buildStatusJSONResponse(report agentStatusReport) statusJSONResponse {
+	response := statusJSONResponse{
+		Root:   report.Root,
+		Agents: make([]statusJSONAgentEntry, 0, len(report.Agents)),
+	}
+	for _, agent := range report.Agents {
+		entry := statusJSONAgentEntry{
+			Name:   agent.Name,
+			Path:   agent.Path,
+			Files:  append([]string(nil), agent.Files...),
+			Status: "valid",
+			Live:   buildStatusJSONLiveStatus(agent),
+		}
+		if agent.Err != nil {
+			entry.Status = "invalid"
+			entry.Error = agent.Err.Error()
+		} else {
+			entry.Config = buildStatusJSONConfig(agent.Config)
+		}
+		response.Agents = append(response.Agents, entry)
+	}
+	return response
+}
+
+func buildStatusJSONConfig(cfg config.Config) *statusJSONConfig {
+	out := &statusJSONConfig{}
+	if value := strings.TrimSpace(cfg.Platform.Name); value != "" {
+		out.Platform = &statusJSONNameField{Name: value}
+	}
+	if value := strings.TrimSpace(cfg.Compute.Class); value != "" {
+		out.Compute = &statusJSONClassField{Class: value}
+	}
+	if value := strings.TrimSpace(cfg.Region.Name); value != "" {
+		out.Region = &statusJSONNameField{Name: value}
+	}
+	if instance := buildStatusJSONInstance(cfg); instance != nil {
+		out.Instance = instance
+	}
+	if image := buildStatusJSONImage(cfg.Image); image != nil {
+		out.Image = image
+	}
+	if runtime := buildStatusJSONRuntime(cfg.Runtime); runtime != nil {
+		out.Runtime = runtime
+	}
+	out.Sandbox = &statusJSONSandbox{
+		Enabled:         cfg.Sandbox.Enabled,
+		NetworkMode:     strings.TrimSpace(cfg.Sandbox.NetworkMode),
+		UseNemoClaw:     cfg.Sandbox.UseNemoClaw,
+		FilesystemAllow: append([]string(nil), cfg.Sandbox.FilesystemAllow...),
+	}
+	if ssh := buildStatusJSONSSH(cfg.SSH); ssh != nil {
+		out.SSH = ssh
+	}
+	if github := buildStatusJSONGitHub(cfg.GitHub); github != nil {
+		out.GitHub = github
+	}
+	if infra := buildStatusJSONInfra(cfg.Infra); infra != nil {
+		out.Infra = infra
+	}
+	return out
+}
+
+func buildStatusJSONInstance(cfg config.Config) *statusJSONInstance {
+	instance := &statusJSONInstance{
+		Type:        strings.TrimSpace(cfg.Instance.Type),
+		DiskSizeGB:  cfg.Instance.DiskSizeGB,
+		NetworkMode: strings.TrimSpace(cfg.Instance.NetworkMode),
+	}
+	if instance.Type == "" && instance.DiskSizeGB == 0 && instance.NetworkMode == "" {
+		return nil
+	}
+	return instance
+}
+
+func buildStatusJSONImage(cfg config.ImageConfig) *statusJSONImage {
+	image := &statusJSONImage{
+		Name: strings.TrimSpace(cfg.Name),
+		ID:   strings.TrimSpace(cfg.ID),
+	}
+	if image.Name == "" && image.ID == "" {
+		return nil
+	}
+	return image
+}
+
+func buildStatusJSONRuntime(cfg config.RuntimeConfig) *statusJSONRuntime {
+	runtime := &statusJSONRuntime{
+		Endpoint:   strings.TrimSpace(cfg.Endpoint),
+		Model:      strings.TrimSpace(cfg.Model),
+		Port:       cfg.Port,
+		Provider:   strings.TrimSpace(cfg.Provider),
+		PublicCIDR: strings.TrimSpace(cfg.PublicCIDR),
+	}
+	if secretID := strings.TrimSpace(cfg.Codex.SecretID); secretID != "" {
+		runtime.Codex = &statusJSONRuntimeCodex{SecretID: secretID}
+	}
+	if runtime.Endpoint == "" && runtime.Model == "" && runtime.Port == 0 && runtime.Provider == "" && runtime.PublicCIDR == "" && runtime.Codex == nil {
+		return nil
+	}
+	return runtime
+}
+
+func buildStatusJSONSSH(cfg config.SSHConfig) *statusJSONSSH {
+	ssh := &statusJSONSSH{
+		KeyName:              strings.TrimSpace(cfg.KeyName),
+		PrivateKeyPath:       strings.TrimSpace(cfg.PrivateKeyPath),
+		GitHubPrivateKeyPath: strings.TrimSpace(cfg.GitHubPrivateKeyPath),
+		CIDR:                 strings.TrimSpace(cfg.CIDR),
+		User:                 strings.TrimSpace(cfg.User),
+	}
+	if ssh.KeyName == "" && ssh.PrivateKeyPath == "" && ssh.GitHubPrivateKeyPath == "" && ssh.CIDR == "" && ssh.User == "" {
+		return nil
+	}
+	return ssh
+}
+
+func buildStatusJSONGitHub(cfg config.GitHubConfig) *statusJSONGitHub {
+	github := &statusJSONGitHub{
+		AuthMode:            strings.TrimSpace(cfg.AuthMode),
+		AppID:               strings.TrimSpace(cfg.AppID),
+		InstallationID:      strings.TrimSpace(cfg.InstallationID),
+		PrivateKeySecretARN: strings.TrimSpace(cfg.PrivateKeySecretARN),
+		TokenSecretARN:      strings.TrimSpace(cfg.TokenSecretARN),
+	}
+	if github.AuthMode == "" && github.AppID == "" && github.InstallationID == "" && github.PrivateKeySecretARN == "" && github.TokenSecretARN == "" {
+		return nil
+	}
+	return github
+}
+
+func buildStatusJSONInfra(cfg config.InfraConfig) *statusJSONInfra {
+	infra := &statusJSONInfra{
+		Backend:     strings.TrimSpace(cfg.Backend),
+		ModuleDir:   strings.TrimSpace(cfg.ModuleDir),
+		AWSProfile:  strings.TrimSpace(cfg.AWSProfile),
+		Environment: strings.TrimSpace(cfg.Environment),
+		InstanceID:  strings.TrimSpace(cfg.InstanceID),
+	}
+	if infra.Backend == "" && infra.ModuleDir == "" && infra.AWSProfile == "" && infra.Environment == "" && infra.InstanceID == "" {
+		return nil
+	}
+	return infra
+}
+
+func buildStatusJSONLiveStatus(agent agentStatusEntry) statusJSONLiveStatus {
+	instanceID := strings.TrimSpace(agent.Config.Infra.InstanceID)
+	if instanceID == "" {
+		return statusJSONLiveStatus{State: "not_provisioned"}
+	}
+	if agent.Live.Err != nil {
+		return statusJSONLiveStatus{
+			State: "unavailable",
+			Error: agent.Live.Err.Error(),
+		}
+	}
+	if agent.Live.Instance == nil {
+		return statusJSONLiveStatus{State: "unavailable"}
+	}
+
+	instance := &statusJSONLiveInstance{
+		ID:               strings.TrimSpace(agent.Live.Instance.ID),
+		Name:             strings.TrimSpace(agent.Live.Instance.Name),
+		State:            strings.TrimSpace(agent.Live.Instance.State),
+		InstanceType:     strings.TrimSpace(agent.Live.Instance.InstanceType),
+		AvailabilityZone: strings.TrimSpace(agent.Live.Instance.AvailabilityZone),
+		PublicIP:         strings.TrimSpace(agent.Live.Instance.PublicIP),
+		PrivateIP:        strings.TrimSpace(agent.Live.Instance.PrivateIP),
+		KeyName:          strings.TrimSpace(agent.Live.Instance.KeyName),
+	}
+	if !agent.Live.Instance.LaunchTime.IsZero() {
+		instance.LaunchTime = agent.Live.Instance.LaunchTime.UTC().Format(time.RFC3339)
+	}
+	return statusJSONLiveStatus{
+		State:    "available",
+		Instance: instance,
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -52,13 +52,13 @@ type statusJSONResponse struct {
 }
 
 type statusJSONAgentEntry struct {
-	Name   string                 `json:"name"`
-	Path   string                 `json:"path"`
-	Files  []string               `json:"files,omitempty"`
-	Status string                 `json:"status"`
-	Error  string                 `json:"error,omitempty"`
-	Config *statusJSONConfig      `json:"config,omitempty"`
-	Live   statusJSONLiveStatus   `json:"live"`
+	Name   string               `json:"name"`
+	Path   string               `json:"path"`
+	Files  []string             `json:"files,omitempty"`
+	Status string               `json:"status"`
+	Error  string               `json:"error,omitempty"`
+	Config *statusJSONConfig    `json:"config,omitempty"`
+	Live   statusJSONLiveStatus `json:"live"`
 }
 
 type statusJSONConfig struct {
@@ -94,11 +94,11 @@ type statusJSONImage struct {
 }
 
 type statusJSONRuntime struct {
-	Endpoint   string                `json:"endpoint,omitempty"`
-	Model      string                `json:"model,omitempty"`
-	Port       int                   `json:"port,omitempty"`
-	Provider   string                `json:"provider,omitempty"`
-	PublicCIDR string                `json:"public_cidr,omitempty"`
+	Endpoint   string                  `json:"endpoint,omitempty"`
+	Model      string                  `json:"model,omitempty"`
+	Port       int                     `json:"port,omitempty"`
+	Provider   string                  `json:"provider,omitempty"`
+	PublicCIDR string                  `json:"public_cidr,omitempty"`
 	Codex      *statusJSONRuntimeCodex `json:"codex,omitempty"`
 }
 

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -243,12 +244,178 @@ runtime:
 	}
 }
 
+func TestStatusCommandOutputsJSON(t *testing.T) {
+	agentsDir := filepath.Join(t.TempDir(), "agents")
+	alphaDir := filepath.Join(agentsDir, "alpha")
+	betaDir := filepath.Join(agentsDir, "beta")
+	if err := os.MkdirAll(alphaDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(alpha) error = %v", err)
+	}
+	if err := os.MkdirAll(betaDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(beta) error = %v", err)
+	}
+
+	writeConfig(t, filepath.Join(alphaDir, "01-base.yaml"), `
+platform:
+  name: aws
+compute:
+  class: gpu
+region:
+  name: us-east-1
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+sandbox:
+  enabled: true
+  network_mode: public
+  use_nemoclaw: true
+  filesystem_allow:
+    - /tmp
+ssh:
+  user: ubuntu
+infra:
+  instance_id: i-0123456789abcdef0
+`)
+	writeConfig(t, filepath.Join(alphaDir, "99-override.yaml"), `
+runtime:
+  provider: aws-bedrock
+  port: 8080
+  public_cidr: 203.0.113.0/24
+  codex:
+    secret_id: codex-secret
+`)
+	writeConfig(t, filepath.Join(betaDir, "config.yaml"), `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: t3.medium
+  disk_size_gb: 20
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+sandbox:
+  enabled: false
+`)
+
+	oldFactory := newAWSProvider
+	t.Cleanup(func() { newAWSProvider = oldFactory })
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+
+	stdout, err := runStatusCommandWithArgs(t, agentsDir, "--output", "json")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var payload statusJSONResponse
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v, stdout = %q", err, stdout)
+	}
+	if payload.Root != agentsDir {
+		t.Fatalf("root = %q, want %q", payload.Root, agentsDir)
+	}
+	if len(payload.Agents) != 2 {
+		t.Fatalf("len(agents) = %d, want 2", len(payload.Agents))
+	}
+
+	alpha := payload.Agents[0]
+	if alpha.Name != "alpha" {
+		t.Fatalf("alpha name = %q, want alpha", alpha.Name)
+	}
+	if alpha.Status != "valid" {
+		t.Fatalf("alpha status = %q, want valid", alpha.Status)
+	}
+	if alpha.Config == nil || alpha.Config.Runtime == nil || alpha.Config.Runtime.Provider != "aws-bedrock" || alpha.Config.Runtime.Port != 8080 {
+		t.Fatalf("alpha runtime = %#v, want provider/port populated", alpha.Config)
+	}
+	if alpha.Config.Runtime.Codex == nil || alpha.Config.Runtime.Codex.SecretID != "codex-secret" {
+		t.Fatalf("alpha runtime codex = %#v, want secret_id", alpha.Config.Runtime.Codex)
+	}
+	if alpha.Config.Sandbox == nil || !alpha.Config.Sandbox.Enabled || alpha.Config.Sandbox.NetworkMode != "public" || !alpha.Config.Sandbox.UseNemoClaw {
+		t.Fatalf("alpha sandbox = %#v, want structured sandbox fields", alpha.Config.Sandbox)
+	}
+	if alpha.Live.State != "available" || alpha.Live.Instance == nil || alpha.Live.Instance.ID != "i-0123456789abcdef0" || alpha.Live.Instance.LaunchTime != "2026-04-06T12:00:00Z" {
+		t.Fatalf("alpha live = %#v, want populated live state", alpha.Live)
+	}
+
+	beta := payload.Agents[1]
+	if beta.Name != "beta" {
+		t.Fatalf("beta name = %q, want beta", beta.Name)
+	}
+	if beta.Live.State != "not_provisioned" {
+		t.Fatalf("beta live state = %q, want not_provisioned", beta.Live.State)
+	}
+}
+
+func TestStatusCommandOutputsJSONForInvalidAgentAndReturnsError(t *testing.T) {
+	agentsDir := filepath.Join(t.TempDir(), "agents")
+	alphaDir := filepath.Join(agentsDir, "alpha")
+	if err := os.MkdirAll(alphaDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(alpha) error = %v", err)
+	}
+
+	writeConfig(t, filepath.Join(alphaDir, "broken.yaml"), `
+platform:
+  name: aws
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+  port: [
+`)
+
+	stdout, err := runStatusCommandWithArgs(t, agentsDir, "--output", "json")
+	if err == nil {
+		t.Fatal("Execute() error = nil, want failure for invalid agent config")
+	}
+
+	var payload statusJSONResponse
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v, stdout = %q", err, stdout)
+	}
+	if len(payload.Agents) != 1 {
+		t.Fatalf("len(agents) = %d, want 1", len(payload.Agents))
+	}
+	if payload.Agents[0].Status != "invalid" {
+		t.Fatalf("status = %q, want invalid", payload.Agents[0].Status)
+	}
+	if !strings.Contains(payload.Agents[0].Error, "parse config") {
+		t.Fatalf("error = %q, want parse config", payload.Agents[0].Error)
+	}
+}
+
+func TestStatusCommandRejectsUnsupportedOutputFormat(t *testing.T) {
+	agentsDir := filepath.Join(t.TempDir(), "agents")
+
+	stdout, err := runStatusCommandWithArgs(t, agentsDir, "--output", "xml")
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unsupported output format error")
+	}
+	if !strings.Contains(stdout, "unsupported output format") {
+		t.Fatalf("stdout = %q, want unsupported output format", stdout)
+	}
+}
+
 func runStatusCommand(t *testing.T, agentsDir string) (string, error) {
+	t.Helper()
+	return runStatusCommandWithArgs(t, agentsDir)
+}
+
+func runStatusCommandWithArgs(t *testing.T, agentsDir string, extraArgs ...string) (string, error) {
 	t.Helper()
 
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
-	os.Args = []string{"agenthub", "status", "--agents-dir", agentsDir}
+	os.Args = append([]string{"agenthub", "status", "--agents-dir", agentsDir}, extraArgs...)
 
 	app := New()
 	cmd := newRootCommand(app)

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -400,8 +400,11 @@ func TestStatusCommandRejectsUnsupportedOutputFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("Execute() error = nil, want unsupported output format error")
 	}
-	if !strings.Contains(stdout, "unsupported output format") {
-		t.Fatalf("stdout = %q, want unsupported output format", stdout)
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty output for unsupported format", stdout)
+	}
+	if !strings.Contains(err.Error(), "unsupported output format") {
+		t.Fatalf("err = %v, want unsupported output format", err)
 	}
 }
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #82 
- [ ] Github issue: Closes: #83 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

• Implemented agenthub inspect --output json in internal/app/inspect.go. The command now supports
  text|json, keeps the existing text report as default, emits a curated JSON response for local
  config, cloud state, remote deployment, and runtime state, and preserves the current non-zero exit
  behavior for partial inspection failures. I also set SilenceErrors so failed JSON output stays
  parseable instead of being mixed with Cobra error text.

  I extended internal/app/inspect_test.go to cover successful JSON output, partial remote failures
  with JSON plus non-zero exit, raw health/status payload inclusion, structured service state, and
  unsupported output formats. The CLI docs now include the JSON form in doc/cli-usage.md.

  Verified with go test ./internal/app -run 'TestInspectCommand'.

<!-- close -->
