### PR TITLE
dry-run support for both config update and redeploy

### DIFF
--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -31,6 +31,14 @@ Re-apply runtime deployment to an existing host:
 agenthub redeploy --config agenthub.yaml
 ```
 
+Preview the managed file changes a redeploy would make without mutating the host:
+
+```bash
+agenthub redeploy --config agenthub.yaml --dry-run
+```
+
+`agenthub redeploy --dry-run` resolves the target over SSH, compares the generated runtime config, systemd unit, and provider environment file against the current host state, and reports that the runtime binary would be replaced. It does not upload files, restart services, or run post-apply verification.
+
 Start the runtime service for one deployed agent:
 
 ```bash
@@ -59,6 +67,12 @@ Show the same status as structured JSON for automation:
 
 ```bash
 agenthub status --output json
+```
+
+Preview config edits without writing the config file:
+
+```bash
+agenthub config update --config agenthub.yaml --dry-run --set runtime.model=gpt-5.4
 ```
 
 Inspect one deployed agent in detail:

--- a/internal/app/config_update.go
+++ b/internal/app/config_update.go
@@ -25,6 +25,7 @@ type configUpdateChange struct {
 func newConfigUpdateCommand(app *App) *cobra.Command {
 	var setValues []string
 	var agentsDir string
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -61,6 +62,11 @@ func newConfigUpdateCommand(app *App) *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout(), "configuration is unchanged")
 				return nil
 			}
+			if dryRun {
+				printConfigUpdateChanges(cmd.OutOrStdout(), changes)
+				fmt.Fprintf(cmd.OutOrStdout(), "dry-run: configuration not written: %s\n", configPath)
+				return nil
+			}
 			if err := config.Save(configPath, cfg); err != nil {
 				return err
 			}
@@ -72,6 +78,7 @@ func newConfigUpdateCommand(app *App) *cobra.Command {
 	}
 	cmd.Flags().StringArrayVar(&setValues, "set", nil, "update a config field with key=value; value is parsed as YAML")
 	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview config changes without writing the file")
 	return cmd
 }
 

--- a/internal/app/redeploy.go
+++ b/internal/app/redeploy.go
@@ -20,6 +20,7 @@ func newRedeployCommand(app *App) *cobra.Command {
 	var port int
 	var useNemoClaw bool
 	var disableNemoClaw bool
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:     "redeploy",
@@ -66,6 +67,33 @@ func newRedeployCommand(app *App) *cobra.Command {
 			printRedeployUpdateSummary(cmd.OutOrStdout(), cfg, workingDir)
 
 			logger := loggerFromContext(cmd.Context())
+			if dryRun {
+				logger.Info("starting redeploy dry-run preview")
+				preview, resolvedTarget, err := runRedeployPreviewWorkflow(cmd.Context(), app.opts.Profile, cfg, installOptions{
+					Target:          targetValue,
+					SSHUser:         sshUser,
+					SSHKey:          sshKey,
+					SSHPort:         sshPort,
+					WorkingDir:      workingDir,
+					Port:            port,
+					UseNemoClaw:     useNemoClaw,
+					DisableNemoClaw: disableNemoClaw,
+				})
+				printRedeployPreview(cmd.OutOrStdout(), preview)
+				if strings.TrimSpace(resolvedTarget) != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), "target: %s\n", resolvedTarget)
+				}
+				if err != nil {
+					return wrapUserFacingError(
+						"redeploy dry-run failed",
+						err,
+						"the target host could not be inspected for a dry-run preview",
+						"confirm SSH access and rerun "+commandRef(cmd.OutOrStdout(), "agenthub", "redeploy", "--config", app.opts.ConfigPath, "--dry-run"),
+					)
+				}
+				return nil
+			}
+
 			logger.Info("starting redeploy workflow")
 
 			installResult, verifyReport, resolvedTarget, err := runRedeployWorkflow(cmd.Context(), app.opts.Profile, cfg, installOptions{
@@ -104,6 +132,7 @@ func newRedeployCommand(app *App) *cobra.Command {
 	cmd.Flags().IntVar(&port, "port", 0, "runtime port override")
 	cmd.Flags().BoolVar(&useNemoClaw, "use-nemoclaw", false, "enable NemoClaw settings for the generated runtime config")
 	cmd.Flags().BoolVar(&disableNemoClaw, "disable-nemoclaw", false, "disable NemoClaw settings for the generated runtime config")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview redeploy changes without mutating the target host")
 	return cmd
 }
 

--- a/internal/app/redeploy_preview.go
+++ b/internal/app/redeploy_preview.go
@@ -1,0 +1,247 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"agenthub/internal/config"
+	"agenthub/internal/host"
+	"agenthub/internal/runtimeinstall"
+)
+
+type redeployPreviewFile struct {
+	Label  string
+	Path   string
+	Status string
+	Diff   string
+}
+
+type redeployPreviewResult struct {
+	Files      []redeployPreviewFile
+	BinaryPath string
+}
+
+func runRedeployPreviewWorkflow(ctx context.Context, profile string, cfg *config.Config, opts installOptions) (redeployPreviewResult, string, error) {
+	if cfg == nil {
+		return redeployPreviewResult{}, "", errors.New("config is required")
+	}
+	if strings.TrimSpace(opts.Target) == "" {
+		return redeployPreviewResult{}, "", errors.New("target is required")
+	}
+
+	networkMode := effectiveNetworkMode(cfg)
+	if networkMode == "private" {
+		return redeployPreviewResult{}, "", errors.New("private networking is not supported yet; redeploy requires SSH access to the instance")
+	}
+	if !config.IsValidNetworkMode(networkMode) && networkMode != "" {
+		return redeployPreviewResult{}, "", fmt.Errorf("unsupported network mode %q", networkMode)
+	}
+
+	resolvedTarget, err := resolveHostTarget(ctx, profile, cfg, opts.Target)
+	if err != nil {
+		return redeployPreviewResult{}, "", err
+	}
+
+	user, keyPath, err := resolveInstallSSH(cfg, opts.SSHUser, opts.SSHKey)
+	if err != nil {
+		return redeployPreviewResult{}, "", err
+	}
+	exec := newSSHExecutor(host.SSHConfig{
+		Host:           resolvedTarget,
+		Port:           opts.SSHPort,
+		User:           user,
+		IdentityFile:   keyPath,
+		ConnectTimeout: 15 * time.Second,
+	})
+	if err := waitForSSHReady(ctx, exec, resolvedTarget); err != nil {
+		return redeployPreviewResult{}, "", err
+	}
+
+	useNemo := cfg.Sandbox.UseNemoClaw
+	if opts.UseNemoClaw {
+		useNemo = true
+	}
+	if opts.DisableNemoClaw {
+		useNemo = false
+	}
+	codexAPIKey, err := resolveCodexAPIKey(ctx, profile, cfg)
+	if err != nil {
+		return redeployPreviewResult{}, "", err
+	}
+
+	artifacts, err := runtimeinstall.PreviewManagedArtifacts(runtimeinstall.Request{
+		Config:       cfg,
+		UseNemoClaw:  &useNemo,
+		Port:         opts.Port,
+		WorkingDir:   opts.WorkingDir,
+		ComputeClass: cfg.Compute.Class,
+		CodexAPIKey:  codexAPIKey,
+	})
+	if err != nil {
+		return redeployPreviewResult{}, "", err
+	}
+
+	files := []struct {
+		label   string
+		path    string
+		content string
+	}{
+		{label: "runtime config", path: artifacts.RuntimeConfigPath, content: string(artifacts.RuntimeConfig)},
+		{label: "systemd unit", path: artifacts.ServicePath, content: string(artifacts.ServiceUnit)},
+	}
+	if strings.TrimSpace(artifacts.ProviderEnvPath) != "" {
+		files = append(files, struct {
+			label   string
+			path    string
+			content string
+		}{
+			label:   "provider environment",
+			path:    artifacts.ProviderEnvPath,
+			content: string(artifacts.ProviderEnv),
+		})
+	}
+
+	result := redeployPreviewResult{BinaryPath: artifacts.BinaryPath}
+	for _, file := range files {
+		current, exists, err := readRemoteManagedFile(ctx, exec, file.path)
+		if err != nil {
+			return redeployPreviewResult{}, resolvedTarget, err
+		}
+		status, diff := previewFileStatus(current, file.content, exists, file.path)
+		result.Files = append(result.Files, redeployPreviewFile{
+			Label:  file.label,
+			Path:   file.path,
+			Status: status,
+			Diff:   diff,
+		})
+	}
+
+	return result, resolvedTarget, nil
+}
+
+func readRemoteManagedFile(ctx context.Context, exec host.Executor, path string) (string, bool, error) {
+	if _, err := exec.Run(ctx, "sudo", "test", "-f", path); err != nil {
+		var remoteErr *host.RemoteCommandError
+		if errors.As(err, &remoteErr) && remoteErr.ExitCode == 1 {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("check remote file %q: %w", path, err)
+	}
+	result, err := exec.Run(ctx, "sudo", "cat", path)
+	if err != nil {
+		return "", true, fmt.Errorf("read remote file %q: %w", path, err)
+	}
+	return result.Stdout, true, nil
+}
+
+func previewFileStatus(current, proposed string, exists bool, path string) (string, string) {
+	if !exists {
+		return "would create", buildUnifiedLineDiff("", proposed, path)
+	}
+	if normalizeTrailingNewline(current) == normalizeTrailingNewline(proposed) {
+		return "unchanged", ""
+	}
+	return "would update", buildUnifiedLineDiff(current, proposed, path)
+}
+
+func printRedeployPreview(out io.Writer, preview redeployPreviewResult) {
+	fmt.Fprintln(out, "dry-run preview")
+	for _, file := range preview.Files {
+		fmt.Fprintf(out, "- %s: %s\n", file.Label, file.Status)
+		fmt.Fprintf(out, "  path: %s\n", file.Path)
+		if strings.TrimSpace(file.Diff) != "" {
+			fmt.Fprintln(out, file.Diff)
+		}
+	}
+	if strings.TrimSpace(preview.BinaryPath) != "" {
+		fmt.Fprintf(out, "- runtime binary: would replace\n")
+		fmt.Fprintf(out, "  path: %s\n", preview.BinaryPath)
+	}
+}
+
+func buildUnifiedLineDiff(before, after, path string) string {
+	beforeLines := splitPreviewLines(before)
+	afterLines := splitPreviewLines(after)
+	ops := diffLines(beforeLines, afterLines)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "  --- current %s\n", path)
+	fmt.Fprintf(&b, "  +++ proposed %s\n", path)
+	for _, op := range ops {
+		prefix := " "
+		switch op.kind {
+		case '-':
+			prefix = "-"
+		case '+':
+			prefix = "+"
+		}
+		fmt.Fprintf(&b, "  %s%s\n", prefix, op.line)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+type diffLineOp struct {
+	kind rune
+	line string
+}
+
+func diffLines(before, after []string) []diffLineOp {
+	dp := make([][]int, len(before)+1)
+	for i := range dp {
+		dp[i] = make([]int, len(after)+1)
+	}
+	for i := len(before) - 1; i >= 0; i-- {
+		for j := len(after) - 1; j >= 0; j-- {
+			if before[i] == after[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+				continue
+			}
+			if dp[i+1][j] >= dp[i][j+1] {
+				dp[i][j] = dp[i+1][j]
+			} else {
+				dp[i][j] = dp[i][j+1]
+			}
+		}
+	}
+
+	ops := make([]diffLineOp, 0, len(before)+len(after))
+	i, j := 0, 0
+	for i < len(before) && j < len(after) {
+		if before[i] == after[j] {
+			ops = append(ops, diffLineOp{kind: ' ', line: before[i]})
+			i++
+			j++
+			continue
+		}
+		if dp[i+1][j] >= dp[i][j+1] {
+			ops = append(ops, diffLineOp{kind: '-', line: before[i]})
+			i++
+			continue
+		}
+		ops = append(ops, diffLineOp{kind: '+', line: after[j]})
+		j++
+	}
+	for ; i < len(before); i++ {
+		ops = append(ops, diffLineOp{kind: '-', line: before[i]})
+	}
+	for ; j < len(after); j++ {
+		ops = append(ops, diffLineOp{kind: '+', line: after[j]})
+	}
+	return ops
+}
+
+func splitPreviewLines(value string) []string {
+	value = normalizeTrailingNewline(value)
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, "\n")
+}
+
+func normalizeTrailingNewline(value string) string {
+	return strings.TrimRight(value, "\n")
+}

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -193,6 +193,75 @@ sandbox:
 	}
 }
 
+func TestConfigUpdateCommandDryRunPrintsChangesWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "default", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+instance:
+  type: t3.medium
+  disk_size_gb: 20
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+sandbox:
+  enabled: false
+`)
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{
+		"agenthub", "config", "update",
+		"--config", path,
+		"--dry-run",
+		"--set", "runtime.model=gpt-5.4",
+		"--set", "sandbox.enabled=true",
+	}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("config file changed during dry-run:\nbefore=%s\nafter=%s", before, after)
+	}
+
+	output := stdout.String()
+	for _, fragment := range []string{
+		"changes:",
+		"runtime.model: llama3.2 -> gpt-5.4",
+		"sandbox.enabled: false -> true",
+		"dry-run: configuration not written:",
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("stdout = %q, want %q", output, fragment)
+		}
+	}
+}
+
 func TestConfigUpdateCommandRequiresSetFlag(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agents", "default", "config.yaml")
@@ -1039,6 +1108,150 @@ sandbox:
 	} {
 		if !strings.Contains(got, fragment) {
 			t.Fatalf("stdout = %q, want %q", got, fragment)
+		}
+	}
+}
+
+func TestRedeployCommandDryRunOutputsPreviewWithoutMutation(t *testing.T) {
+	restore := stubAWSProviderFactory()
+	defer restore()
+
+	var commands []string
+	originalExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				commands = append(commands, key)
+				switch {
+				case key == "true":
+					return host.CommandResult{}, nil
+				case key == "sudo test -f /opt/agenthub/runtime.yaml":
+					return host.CommandResult{}, nil
+				case key == "sudo cat /opt/agenthub/runtime.yaml":
+					return host.CommandResult{Stdout: strings.Join([]string{
+						"use_nemoclaw: false",
+						"nim_endpoint: http://localhost:11434",
+						"model: llama3.2",
+						"port: 8080",
+						"sandbox:",
+						"  enabled: false",
+						"  network_mode: public",
+						"",
+					}, "\n")}, nil
+				case key == "sudo test -f /etc/systemd/system/agenthub.service":
+					return host.CommandResult{}, nil
+				case key == "sudo cat /etc/systemd/system/agenthub.service":
+					return host.CommandResult{Stdout: strings.Join([]string{
+						"[Unit]",
+						"Description=AgentHub runtime",
+						"After=network-online.target",
+						"Wants=network-online.target",
+						"",
+						"[Service]",
+						"Type=simple",
+						"WorkingDirectory=/opt/agenthub",
+						"ExecStart=/opt/agenthub/bin/agenthub serve --runtime-config /opt/agenthub/runtime.yaml --listen 0.0.0.0:8080 --idle-timeout 24h0m0s --idle-shutdown-command \"shutdown -h now\"",
+						"Restart=always",
+						"RestartSec=5",
+						"",
+						"[Install]",
+						"WantedBy=multi-user.target",
+						"",
+					}, "\n")}, nil
+				case key == "sudo test -f /opt/agenthub/agenthub.env":
+					return host.CommandResult{}, &host.RemoteCommandError{Command: "test", Args: []string{"-f", "/opt/agenthub/agenthub.env"}, ExitCode: 1, Err: errors.New("exit status 1")}
+				default:
+					return host.CommandResult{}, errors.New("unexpected command: " + key)
+				}
+			},
+		}
+	}
+	defer func() { newSSHExecutor = originalExecutor }()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "demo.pem")
+	if err := os.WriteFile(keyPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	path := filepath.Join(dir, "agents", "default", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+ssh:
+  private_key_path: `+keyPath+`
+  user: ubuntu
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+  network_mode: public
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.3
+  port: 8080
+  provider: aws-bedrock
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: true
+  network_mode: public
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "--config", path, "redeploy", "--dry-run", "--working-dir", "/opt/agenthub", "--ssh-user", "ubuntu", "--ssh-key", keyPath}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := stdout.String()
+	for _, fragment := range []string{
+		"running redeploy workflow...",
+		"dry-run preview",
+		"- runtime config: would update",
+		"- systemd unit: would update",
+		"- provider environment: would create",
+		"- runtime binary: would replace",
+		"--- current /opt/agenthub/runtime.yaml",
+		"+++ proposed /opt/agenthub/runtime.yaml",
+		"-model: llama3.2",
+		"+model: llama3.3",
+		"target: 203.0.113.10",
+	} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("stdout = %q, want %q", got, fragment)
+		}
+	}
+	for _, forbidden := range []string{
+		"install workflow completed",
+		"verification summary",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("stdout = %q, do not want %q", got, forbidden)
+		}
+	}
+	for _, forbidden := range []string{
+		"sudo systemctl daemon-reload",
+		"sudo systemctl enable --now agenthub.service",
+		"sudo mkdir -p /opt/agenthub",
+		"sudo mv /opt/agenthub/agenthub.service /etc/systemd/system/agenthub.service",
+	} {
+		if slices.Contains(commands, forbidden) {
+			t.Fatalf("commands = %v, do not want %q", commands, forbidden)
 		}
 	}
 }

--- a/internal/runtimeinstall/install.go
+++ b/internal/runtimeinstall/install.go
@@ -102,10 +102,6 @@ func (i Installer) Install(ctx context.Context, req Request) (Result, error) {
 	if backend == nil {
 		backend = ShellBackend{}
 	}
-	workingDir := strings.TrimSpace(req.WorkingDir)
-	if workingDir == "" {
-		workingDir = "/opt/agenthub"
-	}
 
 	report, err := PrereqChecker{
 		Host:          i.Host,
@@ -121,10 +117,11 @@ func (i Installer) Install(ctx context.Context, req Request) (Result, error) {
 		}
 	}
 
-	rendered, err := RenderRuntimeConfig(req.Config, req.UseNemoClaw, req.Port)
+	artifacts, err := PreviewManagedArtifacts(req)
 	if err != nil {
 		return Result{}, err
 	}
+	workingDir := artifacts.WorkingDir
 
 	tmpDir, err := os.MkdirTemp("", "agenthub-install-*")
 	if err != nil {
@@ -133,7 +130,7 @@ func (i Installer) Install(ctx context.Context, req Request) (Result, error) {
 	defer os.RemoveAll(tmpDir)
 
 	localConfigPath := filepath.Join(tmpDir, "runtime.yaml")
-	if err := os.WriteFile(localConfigPath, rendered, 0o600); err != nil {
+	if err := os.WriteFile(localConfigPath, artifacts.RuntimeConfig, 0o600); err != nil {
 		return Result{}, fmt.Errorf("write rendered config: %w", err)
 	}
 
@@ -150,7 +147,7 @@ func (i Installer) Install(ctx context.Context, req Request) (Result, error) {
 		return Result{}, fmt.Errorf("prepare working directory ownership %q: %w", workingDir, err)
 	}
 
-	remoteConfigPath := pathJoin(workingDir, "runtime.yaml")
+	remoteConfigPath := artifacts.RuntimeConfigPath
 	remoteScriptPath := pathJoin(workingDir, "install.sh")
 	if err := i.Host.Upload(ctx, localConfigPath, remoteConfigPath); err != nil {
 		return Result{}, fmt.Errorf("upload runtime config: %w", err)
@@ -221,21 +218,17 @@ func (i Installer) installService(ctx context.Context, req Request, workingDir s
 		return serviceInstallResult{}, err
 	}
 
-	remoteBinaryPath := pathJoin(workingDir, "bin", "agenthub")
-	remoteServicePath := "/etc/systemd/system/agenthub.service"
+	artifacts, err := PreviewManagedArtifacts(req)
+	if err != nil {
+		return serviceInstallResult{}, err
+	}
+
+	remoteBinaryPath := artifacts.BinaryPath
+	remoteServicePath := artifacts.ServicePath
 	stagedBinaryPath := pathJoin(workingDir, "agenthub.upload")
 	stagedServicePath := pathJoin(workingDir, "agenthub.service")
-	remoteEnvPath := pathJoin(workingDir, "agenthub.env")
 	stagedEnvPath := pathJoin(workingDir, "agenthub.env.upload")
-
-	providerName := strings.ToLower(strings.TrimSpace(req.Config.Runtime.Provider))
-	codexAPIKey := strings.TrimSpace(req.CodexAPIKey)
-	envFilePath := ""
-	if providerName == "codex" && codexAPIKey != "" {
-		envFilePath = remoteEnvPath
-	} else if providerName == "aws-bedrock" {
-		envFilePath = remoteEnvPath
-	}
+	envFilePath := artifacts.ProviderEnvPath
 
 	if _, err := i.Host.Run(ctx, "sudo", "mkdir", "-p", pathJoin(workingDir, "bin")); err != nil {
 		return serviceInstallResult{}, fmt.Errorf("prepare runtime binary directory: %w", err)
@@ -261,14 +254,7 @@ func (i Installer) installService(ctx context.Context, req Request, workingDir s
 		defer os.RemoveAll(tmpDir)
 
 		localEnvPath := filepath.Join(tmpDir, "agenthub.env")
-		envContents := ""
-		switch providerName {
-		case "codex":
-			envContents = fmt.Sprintf("OPENAI_API_KEY=%s\n", codexAPIKey)
-		case "aws-bedrock":
-			envContents = fmt.Sprintf("AWS_REGION=%s\nAWS_DEFAULT_REGION=%s\n", strings.TrimSpace(req.Config.Region.Name), strings.TrimSpace(req.Config.Region.Name))
-		}
-		if err := os.WriteFile(localEnvPath, []byte(envContents), 0o600); err != nil {
+		if err := os.WriteFile(localEnvPath, artifacts.ProviderEnv, 0o600); err != nil {
 			return serviceInstallResult{}, fmt.Errorf("write provider environment file: %w", err)
 		}
 		if err := i.Host.Upload(ctx, localEnvPath, stagedEnvPath); err != nil {
@@ -282,22 +268,6 @@ func (i Installer) installService(ctx context.Context, req Request, workingDir s
 		}
 	}
 
-	listenPort := req.Config.Runtime.Port
-	if req.Port > 0 {
-		listenPort = req.Port
-	}
-	if listenPort <= 0 {
-		listenPort = 8080
-	}
-	unitContents := renderSystemdUnit(
-		remoteBinaryPath,
-		pathJoin(workingDir, "runtime.yaml"),
-		listenPort,
-		defaultRuntimeIdleTimeout,
-		defaultRuntimeIdleShutdownCommand,
-		envFilePath,
-	)
-
 	tmpDir, err := os.MkdirTemp("", "agenthub-systemd-*")
 	if err != nil {
 		return serviceInstallResult{}, fmt.Errorf("create temporary service workspace: %w", err)
@@ -305,7 +275,7 @@ func (i Installer) installService(ctx context.Context, req Request, workingDir s
 	defer os.RemoveAll(tmpDir)
 
 	localUnitPath := filepath.Join(tmpDir, "agenthub.service")
-	if err := os.WriteFile(localUnitPath, []byte(unitContents), 0o600); err != nil {
+	if err := os.WriteFile(localUnitPath, artifacts.ServiceUnit, 0o600); err != nil {
 		return serviceInstallResult{}, fmt.Errorf("write systemd unit: %w", err)
 	}
 	if err := i.Host.Upload(ctx, localUnitPath, stagedServicePath); err != nil {

--- a/internal/runtimeinstall/preview.go
+++ b/internal/runtimeinstall/preview.go
@@ -1,0 +1,84 @@
+package runtimeinstall
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ManagedArtifacts describes the managed files a runtime install would place on the target host.
+type ManagedArtifacts struct {
+	WorkingDir        string
+	RuntimeConfigPath string
+	RuntimeConfig     []byte
+	BinaryPath        string
+	ServicePath       string
+	ServiceUnit       []byte
+	ProviderEnvPath   string
+	ProviderEnv       []byte
+}
+
+// PreviewManagedArtifacts renders the managed text artifacts for an install request without mutating a host.
+func PreviewManagedArtifacts(req Request) (ManagedArtifacts, error) {
+	if req.Config == nil {
+		return ManagedArtifacts{}, fmt.Errorf("preview managed artifacts: config is nil")
+	}
+
+	workingDir := strings.TrimSpace(req.WorkingDir)
+	if workingDir == "" {
+		workingDir = "/opt/agenthub"
+	}
+
+	renderedConfig, err := RenderRuntimeConfig(req.Config, req.UseNemoClaw, req.Port)
+	if err != nil {
+		return ManagedArtifacts{}, err
+	}
+
+	remoteBinaryPath := pathJoin(workingDir, "bin", "agenthub")
+	remoteConfigPath := pathJoin(workingDir, "runtime.yaml")
+	remoteServicePath := "/etc/systemd/system/agenthub.service"
+	remoteEnvPath := pathJoin(workingDir, "agenthub.env")
+
+	providerName := strings.ToLower(strings.TrimSpace(req.Config.Runtime.Provider))
+	codexAPIKey := strings.TrimSpace(req.CodexAPIKey)
+	providerEnv := []byte(nil)
+	providerEnvPath := ""
+	switch providerName {
+	case "codex":
+		if codexAPIKey != "" {
+			providerEnvPath = remoteEnvPath
+			providerEnv = []byte(fmt.Sprintf("OPENAI_API_KEY=%s\n", codexAPIKey))
+		}
+	case "aws-bedrock":
+		providerEnvPath = remoteEnvPath
+		region := strings.TrimSpace(req.Config.Region.Name)
+		providerEnv = []byte(fmt.Sprintf("AWS_REGION=%s\nAWS_DEFAULT_REGION=%s\n", region, region))
+	}
+
+	listenPort := req.Config.Runtime.Port
+	if req.Port > 0 {
+		listenPort = req.Port
+	}
+	if listenPort <= 0 {
+		listenPort = 8080
+	}
+
+	unitContents := []byte(renderSystemdUnit(
+		remoteBinaryPath,
+		remoteConfigPath,
+		listenPort,
+		defaultRuntimeIdleTimeout,
+		defaultRuntimeIdleShutdownCommand,
+		providerEnvPath,
+	))
+
+	return ManagedArtifacts{
+		WorkingDir:        workingDir,
+		RuntimeConfigPath: remoteConfigPath,
+		RuntimeConfig:     renderedConfig,
+		BinaryPath:        remoteBinaryPath,
+		ServicePath:       remoteServicePath,
+		ServiceUnit:       unitContents,
+		ProviderEnvPath:   providerEnvPath,
+		ProviderEnv:       providerEnv,
+	}, nil
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #84 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

• Implemented dry-run support for both config update and redeploy.

  agenthub config update --dry-run now computes and prints the same field-level changes without
  writing the config, in internal/app/config_update.go. agenthub redeploy --dry-run now resolves the
  target, reads current managed remote files over SSH, compares them against the generated runtime
  config/unit/env artifacts, and prints per-file status plus a line diff without uploading files or
  restarting services, via internal/app/redeploy.go, internal/app/redeploy_preview.go, internal/
  runtimeinstall/preview.go, and the shared rendering cleanup in internal/runtimeinstall/install.go.

  I added coverage for both dry-run paths in internal/app/root_test.go and documented the new CLI
  behavior in doc/cli-usage.md.

<!-- close -->
