### PR TITLE
supports real key-pair reuse for fresh Terraform workdirs

### DIFF
--- a/infra/aws/ec2/main.tf
+++ b/infra/aws/ec2/main.tf
@@ -210,8 +210,12 @@ locals {
 }
 
 resource "aws_key_pair" "this" {
-  key_name   = "${trimspace(var.ssh_key_name)}-${random_id.suffix.hex}"
+  key_name   = trimspace(var.ssh_key_name)
   public_key = trimspace(var.ssh_public_key)
+
+  lifecycle {
+    ignore_changes = [public_key]
+  }
 }
 
 resource "random_id" "suffix" {

--- a/internal/app/aws_terraform_module_test.go
+++ b/internal/app/aws_terraform_module_test.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAWSEC2ModuleUsesStableSSHKeyName(t *testing.T) {
+	path := filepath.Join("..", "..", "infra", "aws", "ec2", "main.tf")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "key_name   = trimspace(var.ssh_key_name)") {
+		t.Fatalf("AWS module does not use stable ssh_key_name: %q", body)
+	}
+	if strings.Contains(body, `key_name   = "${trimspace(var.ssh_key_name)}-${random_id.suffix.hex}"`) {
+		t.Fatalf("AWS module still appends random suffix to ssh key name: %q", body)
+	}
+	if !strings.Contains(body, "ignore_changes = [public_key]") {
+		t.Fatalf("AWS module is missing key pair ignore_changes lifecycle: %q", body)
+	}
+}

--- a/internal/app/infra_destroy_test.go
+++ b/internal/app/infra_destroy_test.go
@@ -193,6 +193,10 @@ func (b destroyTrackingTerraformBackend) Init(ctx context.Context, workdir strin
 	return nil
 }
 
+func (b destroyTrackingTerraformBackend) Import(ctx context.Context, workdir string, address string, id string) error {
+	return nil
+}
+
 func (b destroyTrackingTerraformBackend) Plan(ctx context.Context, workdir string, varsFile string) error {
 	return nil
 }

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -869,9 +869,9 @@ func TestInfraCreateCommandImportsExistingAWSKeyPairBeforePlan(t *testing.T) {
 			onImport: func(workdir, address, id string) {
 				calls = append(calls, "import:"+address+":"+id)
 			},
-			onPlan: func(workdir, varsFile string) { calls = append(calls, "plan") },
+			onPlan:  func(workdir, varsFile string) { calls = append(calls, "plan") },
 			onApply: func(workdir, varsFile string) { calls = append(calls, "apply") },
-			output: &infratf.InfraOutput{InstanceID: "i-0123456789abcdef0", Region: cfg.Region.Name, NetworkMode: "public"},
+			output:  &infratf.InfraOutput{InstanceID: "i-0123456789abcdef0", Region: cfg.Region.Name, NetworkMode: "public"},
 		}, nil
 	}
 
@@ -3057,11 +3057,11 @@ func (p runtimeURLFallbackCloudProvider) GetInstance(ctx context.Context, region
 }
 
 type fakeTerraformBackend struct {
-	output *infratf.InfraOutput
-	onInit func(workdir string)
+	output   *infratf.InfraOutput
+	onInit   func(workdir string)
 	onImport func(workdir, address, id string)
-	onPlan func(workdir, varsFile string)
-	onApply func(workdir, varsFile string)
+	onPlan   func(workdir, varsFile string)
+	onApply  func(workdir, varsFile string)
 }
 
 func (f fakeTerraformBackend) Init(ctx context.Context, workdir string) error {

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -837,6 +837,161 @@ sandbox:
 	}
 }
 
+func TestInfraCreateCommandImportsExistingAWSKeyPairBeforePlan(t *testing.T) {
+	originalProvider := newAWSProvider
+	originalBackend := newTerraformBackend
+	originalDeriveSSHPublicKey := deriveSSHPublicKeyFunc
+	originalEnsureSSHPrivateKey := ensureSSHPrivateKeyFunc
+	defer func() {
+		newAWSProvider = originalProvider
+		newTerraformBackend = originalBackend
+		deriveSSHPublicKeyFunc = originalDeriveSSHPublicKey
+		ensureSSHPrivateKeyFunc = originalEnsureSSHPrivateKey
+	}()
+
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return keyPairInspectorCloudProvider{
+			stubCloudProvider: stubCloudProvider{profile: profile},
+			exists:            true,
+		}
+	}
+	ensureSSHPrivateKeyFunc = func(ctx context.Context, privateKeyPath string) (string, error) {
+		return privateKeyPath, nil
+	}
+	deriveSSHPublicKeyFunc = func(ctx context.Context, privateKeyPath string) (string, error) {
+		return "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPublicKey agenthub", nil
+	}
+
+	var calls []string
+	newTerraformBackend = func(profile string, cfg *config.Config) (infratf.InfraBackend, error) {
+		return fakeTerraformBackend{
+			onInit: func(workdir string) { calls = append(calls, "init") },
+			onImport: func(workdir, address, id string) {
+				calls = append(calls, "import:"+address+":"+id)
+			},
+			onPlan: func(workdir, varsFile string) { calls = append(calls, "plan") },
+			onApply: func(workdir, varsFile string) { calls = append(calls, "apply") },
+			output: &infratf.InfraOutput{InstanceID: "i-0123456789abcdef0", Region: cfg.Region.Name, NetworkMode: "public"},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agenthub.yaml")
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+ssh:
+  key_name: demo-key
+  private_key_path: /tmp/demo.pem
+  cidr: 203.0.113.0/24
+  user: ubuntu
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+  network_mode: public
+image:
+  id: ami-0123456789abcdef0
+sandbox:
+  enabled: true
+  network_mode: public
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "--config", path, "infra", "create", "--ssh-key-name", "demo-key", "--ssh-cidr", "203.0.113.0/24"}
+
+	app := New()
+	cmd := newRootCommand(app)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	want := []string{"init", "import:aws_key_pair.this:demo-key", "plan", "apply"}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("backend calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestInfraCreateCommandSkipsImportWhenAWSKeyPairDoesNotExist(t *testing.T) {
+	originalProvider := newAWSProvider
+	originalBackend := newTerraformBackend
+	originalDeriveSSHPublicKey := deriveSSHPublicKeyFunc
+	originalEnsureSSHPrivateKey := ensureSSHPrivateKeyFunc
+	defer func() {
+		newAWSProvider = originalProvider
+		newTerraformBackend = originalBackend
+		deriveSSHPublicKeyFunc = originalDeriveSSHPublicKey
+		ensureSSHPrivateKeyFunc = originalEnsureSSHPrivateKey
+	}()
+
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return keyPairInspectorCloudProvider{
+			stubCloudProvider: stubCloudProvider{profile: profile},
+			exists:            false,
+		}
+	}
+	ensureSSHPrivateKeyFunc = func(ctx context.Context, privateKeyPath string) (string, error) {
+		return privateKeyPath, nil
+	}
+	deriveSSHPublicKeyFunc = func(ctx context.Context, privateKeyPath string) (string, error) {
+		return "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestPublicKey agenthub", nil
+	}
+
+	var calls []string
+	newTerraformBackend = func(profile string, cfg *config.Config) (infratf.InfraBackend, error) {
+		return fakeTerraformBackend{
+			onInit:  func(workdir string) { calls = append(calls, "init") },
+			onPlan:  func(workdir, varsFile string) { calls = append(calls, "plan") },
+			onApply: func(workdir, varsFile string) { calls = append(calls, "apply") },
+			output:  &infratf.InfraOutput{InstanceID: "i-0123456789abcdef0", Region: cfg.Region.Name, NetworkMode: "public"},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agenthub.yaml")
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+ssh:
+  key_name: demo-key
+  private_key_path: /tmp/demo.pem
+  cidr: 203.0.113.0/24
+  user: ubuntu
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+  network_mode: public
+image:
+  id: ami-0123456789abcdef0
+sandbox:
+  enabled: true
+  network_mode: public
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "--config", path, "infra", "create", "--ssh-key-name", "demo-key", "--ssh-cidr", "203.0.113.0/24"}
+
+	app := New()
+	cmd := newRootCommand(app)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	want := []string{"init", "plan", "apply"}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("backend calls = %#v, want %#v", calls, want)
+	}
+}
+
 func TestCreateCommandRequiresSSHAccessConfiguration(t *testing.T) {
 	restore := stubAWSProviderFactory()
 	defer restore()
@@ -2865,6 +3020,16 @@ type infraCreateStubCloudProvider struct {
 	stubCloudProvider
 }
 
+type keyPairInspectorCloudProvider struct {
+	stubCloudProvider
+	exists bool
+	err    error
+}
+
+func (p keyPairInspectorCloudProvider) KeyPairExists(ctx context.Context, region, keyName string) (bool, error) {
+	return p.exists, p.err
+}
+
 type cleanupTrackingCloudProvider struct {
 	stubCloudProvider
 	onDelete func(region, instanceID string)
@@ -2893,13 +3058,34 @@ func (p runtimeURLFallbackCloudProvider) GetInstance(ctx context.Context, region
 
 type fakeTerraformBackend struct {
 	output *infratf.InfraOutput
+	onInit func(workdir string)
+	onImport func(workdir, address, id string)
+	onPlan func(workdir, varsFile string)
+	onApply func(workdir, varsFile string)
 }
 
-func (f fakeTerraformBackend) Init(ctx context.Context, workdir string) error { return nil }
+func (f fakeTerraformBackend) Init(ctx context.Context, workdir string) error {
+	if f.onInit != nil {
+		f.onInit(workdir)
+	}
+	return nil
+}
+func (f fakeTerraformBackend) Import(ctx context.Context, workdir string, address string, id string) error {
+	if f.onImport != nil {
+		f.onImport(workdir, address, id)
+	}
+	return nil
+}
 func (f fakeTerraformBackend) Plan(ctx context.Context, workdir string, varsFile string) error {
+	if f.onPlan != nil {
+		f.onPlan(workdir, varsFile)
+	}
 	return nil
 }
 func (f fakeTerraformBackend) Apply(ctx context.Context, workdir string, varsFile string) error {
+	if f.onApply != nil {
+		f.onApply(workdir, varsFile)
+	}
 	return nil
 }
 func (f fakeTerraformBackend) Destroy(ctx context.Context, workdir string, varsFile string) error {

--- a/internal/app/workflows.go
+++ b/internal/app/workflows.go
@@ -118,6 +118,10 @@ type createGroupedStageRunner interface {
 	RunGroup(ctx context.Context, group, title string, fn func(context.Context) error) error
 }
 
+type awsKeyPairInspector interface {
+	KeyPairExists(ctx context.Context, region, keyName string) (bool, error)
+}
+
 func runCreateStage(progress stageRunner, ctx context.Context, group, title string, fn func(context.Context) error) error {
 	if progress == nil {
 		return fn(ctx)
@@ -211,6 +215,23 @@ func runInfraCreate(ctx context.Context, profile string, cfg *config.Config, opt
 		}
 		if err := backend.Init(runCtx, workdir); err != nil {
 			return err
+		}
+		if strings.EqualFold(cfg.Platform.Name, config.PlatformAWS) {
+			inspector, ok := adviser.(awsKeyPairInspector)
+			if ok {
+				keyName := strings.TrimSpace(inputs.SSHKeyName)
+				if keyName != "" {
+					exists, err := inspector.KeyPairExists(runCtx, cfg.Region.Name, keyName)
+					if err != nil {
+						return err
+					}
+					if exists {
+						if err := backend.Import(runCtx, workdir, "aws_key_pair.this", keyName); err != nil {
+							return err
+						}
+					}
+				}
+			}
 		}
 		if err := backend.Plan(runCtx, workdir, varsPath); err != nil {
 			return err

--- a/internal/infra/terraform/backend.go
+++ b/internal/infra/terraform/backend.go
@@ -14,6 +14,7 @@ import (
 
 type InfraBackend interface {
 	Init(ctx context.Context, workdir string) error
+	Import(ctx context.Context, workdir string, address string, id string) error
 	Plan(ctx context.Context, workdir string, varsFile string) error
 	Apply(ctx context.Context, workdir string, varsFile string) error
 	Destroy(ctx context.Context, workdir string, varsFile string) error
@@ -66,6 +67,21 @@ func (t *TerraformBackend) Plan(ctx context.Context, workdir string, varsFile st
 		args = append(args, "-var-file="+varsFile)
 	}
 	return t.run(ctx, workdir, args...)
+}
+
+func (t *TerraformBackend) Import(ctx context.Context, workdir string, address string, id string) error {
+	if err := t.ensureBinary(); err != nil {
+		return err
+	}
+	address = strings.TrimSpace(address)
+	id = strings.TrimSpace(id)
+	if address == "" {
+		return errors.New("terraform import address is required")
+	}
+	if id == "" {
+		return errors.New("terraform import id is required")
+	}
+	return t.run(ctx, workdir, "import", "-input=false", "-no-color", address, id)
 }
 
 func (t *TerraformBackend) Apply(ctx context.Context, workdir string, varsFile string) error {

--- a/internal/infra/terraform/backend_test.go
+++ b/internal/infra/terraform/backend_test.go
@@ -84,3 +84,75 @@ exit 0
 		}
 	}
 }
+
+func TestTerraformBackendImportPassesAWSSettingsToTerraform(t *testing.T) {
+	dir := t.TempDir()
+
+	moduleDir := filepath.Join(dir, "module")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(module) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("terraform {}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(main.tf) error = %v", err)
+	}
+
+	workdir := filepath.Join(dir, "work")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(work) error = %v", err)
+	}
+
+	envFile := filepath.Join(dir, "terraform-env.txt")
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(bin) error = %v", err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+{
+  echo "AWS_PROFILE=${AWS_PROFILE:-}"
+  echo "AWS_SDK_LOAD_CONFIG=${AWS_SDK_LOAD_CONFIG:-}"
+  echo "AWS_REGION=${AWS_REGION:-}"
+  echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}"
+  echo "ARGS=$*"
+} > %q
+exit 0
+`, envFile)
+	terraformPath := filepath.Join(binDir, "terraform")
+	if err := os.WriteFile(terraformPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("WriteFile(terraform) error = %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+
+	backend := &TerraformBackend{
+		Binary:    "terraform",
+		ModuleDir: moduleDir,
+		Profile:   "test-profile",
+		Region:    "us-east-1",
+	}
+
+	if err := backend.Init(context.Background(), workdir); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := backend.Import(context.Background(), workdir, "aws_key_pair.this", "demo-key"); err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("ReadFile(envFile) error = %v", err)
+	}
+	got := string(data)
+	for _, fragment := range []string{
+		"AWS_PROFILE=test-profile",
+		"AWS_SDK_LOAD_CONFIG=1",
+		"AWS_REGION=us-east-1",
+		"AWS_DEFAULT_REGION=us-east-1",
+		"ARGS=import -input=false -no-color aws_key_pair.this demo-key",
+	} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("env output = %q, want %q", got, fragment)
+		}
+	}
+}

--- a/internal/provider/aws/provider.go
+++ b/internal/provider/aws/provider.go
@@ -57,6 +57,7 @@ type ec2Client interface {
 	DescribeRegions(ctx context.Context, params *ec2.DescribeRegionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRegionsOutput, error)
 	DescribeInstanceTypes(ctx context.Context, params *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
 	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	DescribeKeyPairs(ctx context.Context, params *ec2.DescribeKeyPairsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeKeyPairsOutput, error)
 	TerminateInstances(ctx context.Context, params *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
 }
 
@@ -236,6 +237,43 @@ func (p *Provider) RecommendInstanceTypes(ctx context.Context, region, computeCl
 
 func (p *Provider) ListInstanceTypes(ctx context.Context, region string) ([]provider.InstanceType, error) {
 	return p.RecommendInstanceTypes(ctx, region, p.Config.ComputeClass)
+}
+
+func (p *Provider) KeyPairExists(ctx context.Context, region, keyName string) (bool, error) {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return false, errors.New("region is required")
+	}
+	keyName = strings.TrimSpace(keyName)
+	if keyName == "" {
+		return false, errors.New("key name is required")
+	}
+
+	cfg, err := p.loadAWSConfig(ctx)
+	if err != nil {
+		return false, err
+	}
+	cfg.Region = region
+
+	client := p.newEC2Client(cfg)
+	out, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
+		KeyNames: []string{keyName},
+	})
+	if err != nil {
+		if isAWSMissingKeyPairError(err) {
+			return false, nil
+		}
+		if isPermissionDenied(err) {
+			return false, &AuthError{
+				Kind:    "permission_denied",
+				Profile: p.Config.Profile,
+				Stage:   authStageAPI,
+				Cause:   fmt.Errorf("describe EC2 key pair %q in region %s: %w", keyName, region, err),
+			}
+		}
+		return false, fmt.Errorf("describe EC2 key pair %q in region %s: %w", keyName, region, err)
+	}
+	return len(out.KeyPairs) > 0, nil
 }
 
 func filterInstanceTypesByComputeClass(items []provider.InstanceType, computeClass string) []provider.InstanceType {
@@ -752,6 +790,19 @@ func isPermissionDenied(err error) bool {
 
 	lower := strings.ToLower(err.Error())
 	return strings.Contains(lower, "access denied") || strings.Contains(lower, "not authorized") || strings.Contains(lower, "unauthorized")
+}
+
+func isAWSMissingKeyPairError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := strings.TrimSpace(apiErr.ErrorCode())
+		return code == "InvalidKeyPair.NotFound"
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "invalidkeypair.notfound")
 }
 
 func awsString(value *string) string {

--- a/internal/provider/aws/provider_test.go
+++ b/internal/provider/aws/provider_test.go
@@ -398,6 +398,78 @@ func TestCheckGPUQuotaUsesServiceQuotasUtilizationReport(t *testing.T) {
 	}
 }
 
+func TestKeyPairExistsReturnsTrueWhenAWSReturnsKeyPair(t *testing.T) {
+	p := &Provider{
+		Config: Config{Profile: "test-profile"},
+		loadDefaultConfig: func(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (awsbase.Config, error) {
+			return awsbase.Config{Region: "us-east-1"}, nil
+		},
+		newEC2Client: func(cfg awsbase.Config) ec2Client {
+			if cfg.Region != "us-west-2" {
+				t.Fatalf("cfg.Region = %q, want us-west-2", cfg.Region)
+			}
+			return &fakeEC2Client{
+				describeKeyPairsOut: &ec2.DescribeKeyPairsOutput{
+					KeyPairs: []ec2types.KeyPairInfo{{KeyName: awsbase.String("demo-key")}},
+				},
+			}
+		},
+	}
+
+	exists, err := p.KeyPairExists(context.Background(), "us-west-2", "demo-key")
+	if err != nil {
+		t.Fatalf("KeyPairExists() error = %v", err)
+	}
+	if !exists {
+		t.Fatal("KeyPairExists() = false, want true")
+	}
+}
+
+func TestKeyPairExistsReturnsFalseWhenAWSReportsMissingKeyPair(t *testing.T) {
+	p := &Provider{
+		Config: Config{Profile: "test-profile"},
+		loadDefaultConfig: func(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (awsbase.Config, error) {
+			return awsbase.Config{Region: "us-east-1"}, nil
+		},
+		newEC2Client: func(cfg awsbase.Config) ec2Client {
+			return &fakeEC2Client{
+				describeKeyPairsErr: missingKeyPairError{},
+			}
+		},
+	}
+
+	exists, err := p.KeyPairExists(context.Background(), "us-west-2", "demo-key")
+	if err != nil {
+		t.Fatalf("KeyPairExists() error = %v", err)
+	}
+	if exists {
+		t.Fatal("KeyPairExists() = true, want false")
+	}
+}
+
+func TestKeyPairExistsWrapsAuthErrors(t *testing.T) {
+	p := &Provider{
+		Config: Config{Profile: "test-profile"},
+		loadDefaultConfig: func(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (awsbase.Config, error) {
+			return awsbase.Config{Region: "us-east-1"}, nil
+		},
+		newEC2Client: func(cfg awsbase.Config) ec2Client {
+			return &fakeEC2Client{
+				describeKeyPairsErr: accessDeniedError{},
+			}
+		},
+	}
+
+	_, err := p.KeyPairExists(context.Background(), "us-west-2", "demo-key")
+	if err == nil {
+		t.Fatal("KeyPairExists() error = nil")
+	}
+	authErr := mustAuthError(t, err)
+	if authErr.Kind != "permission_denied" {
+		t.Fatalf("AuthError.Kind = %q, want permission_denied", authErr.Kind)
+	}
+}
+
 func mustAuthError(t *testing.T, err error) *AuthError {
 	t.Helper()
 	var authErr *AuthError
@@ -493,6 +565,8 @@ type fakeEC2Client struct {
 	associatePublicIP        bool
 	describeRegionsOut       *ec2.DescribeRegionsOutput
 	describeInstanceTypesOut *ec2.DescribeInstanceTypesOutput
+	describeKeyPairsOut      *ec2.DescribeKeyPairsOutput
+	describeKeyPairsErr      error
 	instanceTags             []ec2types.Tag
 }
 
@@ -508,6 +582,16 @@ func (f *fakeEC2Client) DescribeInstanceTypes(ctx context.Context, params *ec2.D
 		return f.describeInstanceTypesOut, nil
 	}
 	return &ec2.DescribeInstanceTypesOutput{}, nil
+}
+
+func (f *fakeEC2Client) DescribeKeyPairs(ctx context.Context, params *ec2.DescribeKeyPairsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeKeyPairsOutput, error) {
+	if f.describeKeyPairsErr != nil {
+		return nil, f.describeKeyPairsErr
+	}
+	if f.describeKeyPairsOut != nil {
+		return f.describeKeyPairsOut, nil
+	}
+	return &ec2.DescribeKeyPairsOutput{}, nil
 }
 
 func (f *fakeEC2Client) CreateSecurityGroup(ctx context.Context, params *ec2.CreateSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.CreateSecurityGroupOutput, error) {
@@ -597,4 +681,22 @@ func (f *fakeEC2Client) DescribeInstances(ctx context.Context, params *ec2.Descr
 
 func (f *fakeEC2Client) TerminateInstances(ctx context.Context, params *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
 	return &ec2.TerminateInstancesOutput{}, nil
+}
+
+type missingKeyPairError struct{}
+
+func (missingKeyPairError) Error() string {
+	return "InvalidKeyPair.NotFound: missing"
+}
+
+func (missingKeyPairError) ErrorCode() string {
+	return "InvalidKeyPair.NotFound"
+}
+
+func (missingKeyPairError) ErrorMessage() string {
+	return "missing"
+}
+
+func (missingKeyPairError) ErrorFault() smithy.ErrorFault {
+	return smithy.FaultClient
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #97 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

Implemented on fix/reuse-existing-ssh-key. The worktree is clean, and the latest local commit is
  8564f2e.

  The AWS create flow now supports real key-pair reuse for fresh Terraform workdirs: agenthub
  create / agenthub infra create checks whether the configured AWS key pair already exists, imports
  aws_key_pair.this before terraform plan when it does, and only creates it when it does not. The
  Terraform backend now exposes Import(...), the AWS provider exposes KeyPairExists(...), and the
  EC2 module uses the stable ssh_key_name directly with ignore_changes = [public_key] so same-name
  imported key pairs are not auto-replaced.

  I also added coverage for the new backend import command, AWS key-pair lookup behavior, import-vs-
  skip workflow ordering, and a static regression test for the Terraform module shape. Verified
  with:

  go test ./internal/infra/terraform ./internal/provider/aws ./internal/app

<!-- close -->