### PR TITLE
migration in a single workflow file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,19 +2,10 @@ name: Publish
 
 on:
     push:
+        branches:
+            - main
         tags:
             - 'v*'
-    workflow_dispatch:
-        inputs:
-            bump:
-                description: 'Version bump to apply to the latest release tag'
-                required: true
-                type: choice
-                default: patch
-                options:
-                    - patch
-                    - minor
-                    - major
 
 concurrency:
     group: publish-${{ github.ref }}
@@ -22,16 +13,45 @@ concurrency:
 
 permissions:
     contents: write
+    pull-requests: write
 
 jobs:
+    tagpr:
+        name: Create release PR
+        if: github.ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Validate tagpr token
+              shell: bash
+              env:
+                  TAGPR_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+              run: |
+                  set -euo pipefail
+
+                  if [[ -z "${TAGPR_TOKEN}" ]]; then
+                    echo "TAGPR_TOKEN secret is required so tag creation triggers the publish job" >&2
+                    exit 1
+                  fi
+
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.TAGPR_TOKEN }}
+
+            - name: Run tagpr
+              uses: Songmu/tagpr@main
+              env:
+                  GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+
     prepare:
         name: Release version
+        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         outputs:
             version: ${{ steps.resolve.outputs.version }}
             previous_tag: ${{ steps.resolve.outputs.previous_tag }}
             target_ref: ${{ steps.resolve.outputs.target_ref }}
-            mode: ${{ steps.resolve.outputs.mode }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -41,71 +61,24 @@ jobs:
             - name: Resolve version
               id: resolve
               shell: bash
-              env:
-                  BUMP: ${{ inputs.bump }}
               run: |
                   set -euo pipefail
 
-                  latest_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 || true)"
+                  version="${GITHUB_REF_NAME}"
                   target_ref="${GITHUB_SHA}"
-
-                  bump_version() {
-                    local base_tag="$1"
-                    local bump="$2"
-                    local version="${base_tag#v}"
-                    local major minor patch
-                    IFS='.' read -r major minor patch <<< "${version}"
-
-                    case "${bump}" in
-                      patch)
-                        patch=$((patch + 1))
-                        ;;
-                      minor)
-                        minor=$((minor + 1))
-                        patch=0
-                        ;;
-                      major)
-                        major=$((major + 1))
-                        minor=0
-                        patch=0
-                        ;;
-                      *)
-                        echo "unsupported bump type: ${bump}" >&2
-                        exit 1
-                        ;;
-                    esac
-
-                    printf 'v%s.%s.%s\n' "${major}" "${minor}" "${patch}"
-                  }
-
-                  if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
-                    version="${GITHUB_REF_NAME}"
-                    if ! [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                      echo "push tag must match vX.Y.Z, got ${version}" >&2
-                      exit 1
-                    fi
-                    previous_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -Fxv "${version}" | head -n 1 || true)"
-                    mode="existing-tag"
-                  else
-                    if [[ -z "${latest_tag}" ]]; then
-                      version="v0.1.0"
-                      previous_tag=""
-                      mode="initial-tag"
-                      echo "no prior semver tag found; using initial release version ${version}"
-                    else
-                      version="$(bump_version "${latest_tag}" "${BUMP}")"
-                      previous_tag="${latest_tag}"
-                      mode="bumped-tag"
-                    fi
+                  if ! [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "push tag must match vX.Y.Z, got ${version}" >&2
+                    exit 1
                   fi
+                  previous_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -Fxv "${version}" | head -n 1 || true)"
 
                   echo "version=${version}" >> "${GITHUB_OUTPUT}"
                   echo "previous_tag=${previous_tag}" >> "${GITHUB_OUTPUT}"
                   echo "target_ref=${target_ref}" >> "${GITHUB_OUTPUT}"
-                  echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
 
     build:
         name: Build artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         needs: prepare
         strategy:
@@ -167,6 +140,7 @@ jobs:
 
     release:
         name: Publish release
+        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         needs:
             - prepare

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,7 @@
+# tagpr configuration
+# https://github.com/Songmu/tagpr
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	release = false
+	changelog = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,4 +127,4 @@ GitHub issue templates are available for bugs, features, improvements, design pr
 
 ## Release Notes
 
-Release publishing is handled by GitHub Actions. Contributors do not need to build release artifacts manually for normal PRs, but user-visible changes should be described clearly in commits and pull requests because release notes are generated from git history.
+Release publishing is handled by GitHub Actions. Pushes to `main` update the `tagpr` release PR, and merging that PR creates the semver tag that triggers the publish workflow. Contributors do not need to build release artifacts manually for normal PRs, but user-visible changes should be described clearly in commits and pull requests because release notes are generated from git history.


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

Implemented the migration in a single workflow file.

  .github/workflows/publish.yml now does two things: on main pushes it runs a tagpr job to open/
  update the release PR, and on v* tag pushes it runs the existing publish path. The old manual
  workflow_dispatch bump logic is gone, and the tag-driven publish path now resolves VERSION
  directly from the pushed tag. I also added .tagpr:1 in tag-only mode with release = false so
  tagpr does not create a competing GitHub Release, and updated CONTRIBUTING.md:128 to describe the
  new release flow.

  I verified that .github/workflows/publish.yml parses as valid YAML. I did not run the GitHub
  Actions workflow itself locally. The remaining setup requirement is a TAGPR_TOKEN repository
  secret with permission to create PRs/tags in a way that triggers downstream workflows; without
  it, the new tagpr job will fail intentionally.


<!-- close -->
