### PR TITLE
update: swapped the tagpr auth flow in publish.yml:1 from secrets.TAG…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,28 +21,42 @@ jobs:
         if: github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         steps:
-            - name: Validate tagpr token
+            - name: Validate GitHub App settings
               shell: bash
               env:
-                  TAGPR_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+                  TAGPR_APP_ID: ${{ vars.TAGPR_APP_ID }}
+                  TAGPR_APP_PRIVATE_KEY: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
               run: |
                   set -euo pipefail
 
-                  if [[ -z "${TAGPR_TOKEN}" ]]; then
-                    echo "TAGPR_TOKEN secret is required so tag creation triggers the publish job" >&2
+                  if [[ -z "${TAGPR_APP_ID}" ]]; then
+                    echo "TAGPR_APP_ID repository variable is required to mint the GitHub App token for tagpr" >&2
                     exit 1
                   fi
+
+                  if [[ -z "${TAGPR_APP_PRIVATE_KEY}" ]]; then
+                    echo "TAGPR_APP_PRIVATE_KEY secret is required to mint the GitHub App token for tagpr" >&2
+                    exit 1
+                  fi
+
+            - name: Create GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@v2
+              with:
+                  app-id: ${{ vars.TAGPR_APP_ID }}
+                  private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
 
             - name: Checkout
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.TAGPR_TOKEN }}
+                  token: ${{ steps.app-token.outputs.token }}
+                  persist-credentials: false
 
             - name: Run tagpr
               uses: Songmu/tagpr@main
               env:
-                  GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
     prepare:
         name: Release version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,4 +127,4 @@ GitHub issue templates are available for bugs, features, improvements, design pr
 
 ## Release Notes
 
-Release publishing is handled by GitHub Actions. Pushes to `main` update the `tagpr` release PR, and merging that PR creates the semver tag that triggers the publish workflow. Contributors do not need to build release artifacts manually for normal PRs, but user-visible changes should be described clearly in commits and pull requests because release notes are generated from git history.
+Release publishing is handled by GitHub Actions. Pushes to `main` update the `tagpr` release PR, and merging that PR creates the semver tag that triggers the publish workflow. The `tagpr` job uses a GitHub App token minted from `TAGPR_APP_ID` and `TAGPR_APP_PRIVATE_KEY`, so release automation does not depend on a personal access token. Contributors do not need to build release artifacts manually for normal PRs, but user-visible changes should be described clearly in commits and pull requests because release notes are generated from git history.


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.


## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
• Swapped the tagpr auth flow in .github/workflows/publish.yml:1 from secrets.TAGPR_TOKEN to a
  GitHub App token minted by actions/create-github-app-token@v2. The workflow now validates
  vars.TAGPR_APP_ID and secrets.TAGPR_APP_PRIVATE_KEY, creates an installation token, and uses that
  token for both checkout and Songmu/tagpr. I also updated CONTRIBUTING.md:128 to document the new
  setup.

  I verified the workflow YAML parses successfully. I did not run the GitHub Actions flow end-to-
  end, so the remaining requirement is to configure the GitHub App and add TAGPR_APP_ID plus
  TAGPR_APP_PRIVATE_KEY in the repository settings.

<!-- close -->
