### PR TITLE
fix: the failure mode from run 24277842472

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
     assign-label:
+        if: ${{ github.event_name == 'pull_request' }}
         permissions:
             contents: read
             pull-requests: write


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

The root cause is concrete: this run was triggered by an issues event, but the job assumes PR metadata and sends GitHub API requests with empty PR_NUMBER and HEAD_REF, which produces the 404. I’m reading the workflow now to tighten the event gating.

• I’m editing the workflow to skip the PR-only labeling job on issue events, which keeps the existing issue-triggered jobs intact and removes the bad API call path. The patch is in place. I’m validating the diff and the workflow file shape before I stop.

<!-- close -->
