### PR TITLE
Runtime service control commands

### DIFF
--- a/internal/app/runtime_service.go
+++ b/internal/app/runtime_service.go
@@ -297,12 +297,22 @@ func runtimeServiceActionAlreadySatisfied(action string, state inspectServiceSta
 	case "start":
 		return strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
 	case "stop":
-		return !strings.EqualFold(strings.TrimSpace(state.ActiveState), "active")
+		return runtimeServiceIsStopped(state)
 	case "restart":
 		return false
 	default:
 		return false
 	}
+}
+
+func runtimeServiceIsStopped(state inspectServiceState) bool {
+	activeState := strings.ToLower(strings.TrimSpace(state.ActiveState))
+	subState := strings.ToLower(strings.TrimSpace(state.SubState))
+
+	if activeState == "inactive" {
+		return true
+	}
+	return activeState == "" && (subState == "" || subState == "dead")
 }
 
 func runtimeServiceAlreadySatisfiedMessage(action string) string {

--- a/internal/app/runtime_service_test.go
+++ b/internal/app/runtime_service_test.go
@@ -480,6 +480,81 @@ sandbox:
 	}
 }
 
+func TestRuntimeStopCommandStopsFailedService(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "alpha", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-west-2
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+infra:
+  instance_id: i-0123456789abcdef0
+sandbox:
+  enabled: false
+`)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+
+	oldProvider := newAWSProvider
+	newAWSProvider = func(profile, computeClass string) provider.CloudProvider {
+		return fakeStatusCloudProvider{}
+	}
+	t.Cleanup(func() { newAWSProvider = oldProvider })
+
+	var stopCalls int
+	var inspectCalls int
+	oldExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				key := strings.TrimSpace(command + " " + strings.Join(args, " "))
+				switch {
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc" && strings.Contains(args[1], `unit="agenthub.service"`):
+					inspectCalls++
+					if inspectCalls == 1 {
+						return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=failed\nSubState=failed\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+					}
+					return host.CommandResult{Stdout: "installed=true\nLoadState=loaded\nActiveState=inactive\nSubState=dead\nUnitFileState=enabled\nFragmentPath=/etc/systemd/system/agenthub.service\n"}, nil
+				case key == "sudo systemctl stop agenthub.service":
+					stopCalls++
+					return host.CommandResult{}, nil
+				}
+				if result, ok := defaultFlexibleCommand(command, args...); ok {
+					return result, nil
+				}
+				return host.CommandResult{}, errors.New("unexpected command: " + key)
+			},
+		}
+	}
+	t.Cleanup(func() { newSSHExecutor = oldExecutor })
+
+	stdout, err := runRuntimeStopCommand(t, []string{"--config", path, "--ssh-user", "ubuntu", "--ssh-key", keyPath})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("stopCalls = %d, want 1", stopCalls)
+	}
+	if !strings.Contains(stdout, "result: runtime service stopped") {
+		t.Fatalf("stdout = %q, want stopped message", stdout)
+	}
+}
+
 func TestRuntimeStopCommandFailsWhenServiceMissing(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agents", "alpha", "config.yaml")


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #63 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

Implemented one real gap in the runtime service controls and kept it split into two small commits. The change is in internal/app/runtime_service.go:295. runtime stop no longer treats a failed systemd unit as “already stopped”; it now issues systemctl stop unless the unit is actually inactive/dead. The regression coverage is in internal/app/ runtime_service_test.go:482.
<!-- close -->