### PR TITLE
Additive --agent Flag Set for Non-Interactive Agent Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ agenthub init
 Provision from a config file:
 
 ```bash
-agenthub create --config agenthub.yaml
+agenthub create --agent alpha
+```
+
+Or use the lower-level config path directly:
+
+```bash
+agenthub create --config agents/alpha/config.yaml
 ```
 
 Inspect one deployed agent:

--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -10,10 +10,16 @@ Run the interactive setup:
 agenthub init
 ```
 
-Create infrastructure from a config file:
+Create infrastructure for a named agent:
 
 ```bash
-agenthub create --config agenthub.yaml
+agenthub create --agent alpha
+```
+
+Use the lower-level config path directly when needed:
+
+```bash
+agenthub create --config agents/alpha/config.yaml
 ```
 
 Notes:
@@ -118,7 +124,7 @@ This is the supported teardown path for one deployed agent. It preserves the loc
 Deploy the Slack integration:
 
 ```bash
-agenthub slack deploy --config agenthub.yaml
+agenthub slack deploy --agent alpha
 ```
 
 `agenthub slack deploy` uses `infra.instance_id` from the config created by `agenthub create`. Pass `--target` if you want to override it.

--- a/internal/app/agent_selection.go
+++ b/internal/app/agent_selection.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"agenthub/internal/prompt"
+)
+
+type agentConfigResolutionOptions struct {
+	ConfigPath       string
+	AgentName        string
+	AgentsDir        string
+	Session          *prompt.Session
+	AllowInteractive bool
+	RequireConfig    bool
+}
+
+func resolveAgentConfigPath(opts agentConfigResolutionOptions) (string, error) {
+	configPath := strings.TrimSpace(opts.ConfigPath)
+	agentName := strings.TrimSpace(opts.AgentName)
+
+	if configPath != "" && agentName != "" {
+		return "", errors.New("--config and --agent are mutually exclusive; pass only one")
+	}
+	if configPath != "" {
+		return configPath, nil
+	}
+	if agentName != "" {
+		resolvedPath := agentConfigPath(opts.AgentsDir, agentName)
+		if _, err := os.Stat(resolvedPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return "", fmt.Errorf("agent config file not found for --agent %q: expected %s", agentName, resolvedPath)
+			}
+			return "", fmt.Errorf("stat agent config %q: %w", resolvedPath, err)
+		}
+		return resolvedPath, nil
+	}
+	if opts.AllowInteractive {
+		return selectAgentConfigPath(opts.Session, opts.AgentsDir)
+	}
+	if opts.RequireConfig {
+		return "", errors.New("config file is required: pass --config <path> or --agent <name>")
+	}
+	return "", nil
+}
+
+func agentConfigPath(agentsDir, agentName string) string {
+	root := strings.TrimSpace(agentsDir)
+	if root == "" {
+		root = "agents"
+	}
+	return filepath.Join(root, strings.TrimSpace(agentName), "config.yaml")
+}

--- a/internal/app/agent_selection_test.go
+++ b/internal/app/agent_selection_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveAgentConfigPathResolvesAgentName(t *testing.T) {
+	dir := t.TempDir()
+	configPath := agentConfigPath(dir, "alpha")
+	if err := writeMinimalAgentConfig(configPath); err != nil {
+		t.Fatalf("writeMinimalAgentConfig() error = %v", err)
+	}
+
+	got, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+		AgentName:     "alpha",
+		AgentsDir:     dir,
+		RequireConfig: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveAgentConfigPath() error = %v", err)
+	}
+	if got != configPath {
+		t.Fatalf("resolveAgentConfigPath() = %q, want %q", got, configPath)
+	}
+}
+
+func TestResolveAgentConfigPathRejectsConfigAndAgent(t *testing.T) {
+	_, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+		ConfigPath: "agents/alpha/config.yaml",
+		AgentName:  "alpha",
+	})
+	if err == nil {
+		t.Fatal("resolveAgentConfigPath() error = nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually exclusive message", err)
+	}
+}
+
+func TestResolveAgentConfigPathReportsMissingAgentConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+		AgentName:     "missing",
+		AgentsDir:     dir,
+		RequireConfig: true,
+	})
+	if err == nil {
+		t.Fatal("resolveAgentConfigPath() error = nil")
+	}
+	if !strings.Contains(err.Error(), agentConfigPath(dir, "missing")) {
+		t.Fatalf("error = %v, want expected path", err)
+	}
+}
+
+func TestResolveAgentConfigPathAllowsEmptyWhenConfigOptional(t *testing.T) {
+	got, err := resolveAgentConfigPath(agentConfigResolutionOptions{})
+	if err != nil {
+		t.Fatalf("resolveAgentConfigPath() error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("resolveAgentConfigPath() = %q, want empty path", got)
+	}
+}

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -27,22 +27,25 @@ func newCreateCommand(app *App) *cobra.Command {
 	var useNemoClaw bool
 	var disableNemoClaw bool
 	var agentsDir string
+	var agentName string
 
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create and verify a new environment",
 		GroupID: "provision",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath := strings.TrimSpace(app.opts.ConfigPath)
-			if configPath == "" {
-				session := prompt.NewSession(cmd.InOrStdin(), cmd.OutOrStdout())
-				selectedConfigPath, err := selectAgentConfigPath(session, agentsDir)
-				if err != nil {
-					return err
-				}
-				configPath = selectedConfigPath
-				app.opts.ConfigPath = configPath
+			configPath, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+				ConfigPath:       app.opts.ConfigPath,
+				AgentName:        agentName,
+				AgentsDir:        agentsDir,
+				Session:          prompt.NewSession(cmd.InOrStdin(), cmd.OutOrStdout()),
+				AllowInteractive: true,
+				RequireConfig:    true,
+			})
+			if err != nil {
+				return err
 			}
+			app.opts.ConfigPath = configPath
 			cfg, err := config.Load(configPath)
 			if err != nil {
 				return err
@@ -123,6 +126,7 @@ func newCreateCommand(app *App) *cobra.Command {
 	cmd.Flags().IntVar(&port, "port", 0, "runtime port override")
 	cmd.Flags().BoolVar(&useNemoClaw, "use-nemoclaw", false, "enable NemoClaw settings for the generated runtime config")
 	cmd.Flags().BoolVar(&disableNemoClaw, "disable-nemoclaw", false, "disable NemoClaw settings for the generated runtime config")
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent name to resolve under the agents directory")
 	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
 	return cmd
 }

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -21,16 +21,25 @@ func newInstallCommand(app *App) *cobra.Command {
 	var port int
 	var useNemoClaw bool
 	var disableNemoClaw bool
+	var agentName string
+	var agentsDir string
 
 	cmd := &cobra.Command{
 		Use:     "install",
 		Short:   "Install the AgentHub runtime on a prepared host",
 		GroupID: "provision",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if strings.TrimSpace(app.opts.ConfigPath) == "" {
-				return errors.New("config file is required: pass --config <path>")
+			configPath, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+				ConfigPath:    app.opts.ConfigPath,
+				AgentName:     agentName,
+				AgentsDir:     agentsDir,
+				RequireConfig: true,
+			})
+			if err != nil {
+				return err
 			}
-			cfg, err := config.Load(app.opts.ConfigPath)
+			app.opts.ConfigPath = configPath
+			cfg, err := config.Load(configPath)
 			if err != nil {
 				return err
 			}
@@ -55,13 +64,13 @@ func newInstallCommand(app *App) *cobra.Command {
 				DisableNemoClaw: disableNemoClaw,
 			})
 			printInstallResult(cmd.OutOrStdout(), result)
-			printSuccessNextSteps(cmd.OutOrStdout(), app.opts.ConfigPath, resolvedTarget, false)
+			printSuccessNextSteps(cmd.OutOrStdout(), configPath, resolvedTarget, false)
 			if err != nil {
 				return wrapUserFacingError(
 					"install failed",
 					err,
 					"the SSH target is unreachable or the host prerequisites are missing",
-					"run "+commandRef(cmd.OutOrStdout(), "agenthub", "verify", "--config", app.opts.ConfigPath, "--target", resolvedTarget)+" after fixing the host",
+					"run "+commandRef(cmd.OutOrStdout(), "agenthub", "verify", "--config", configPath, "--target", resolvedTarget)+" after fixing the host",
 					"check Docker, GPU drivers, and SSH access on the target host",
 				)
 			}
@@ -77,6 +86,8 @@ func newInstallCommand(app *App) *cobra.Command {
 	cmd.Flags().IntVar(&port, "port", 0, "runtime port override")
 	cmd.Flags().BoolVar(&useNemoClaw, "use-nemoclaw", false, "enable NemoClaw settings for the generated runtime config")
 	cmd.Flags().BoolVar(&disableNemoClaw, "disable-nemoclaw", false, "disable NemoClaw settings for the generated runtime config")
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent name to resolve under the agents directory")
+	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
 	return cmd
 }
 

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -1887,6 +1887,240 @@ runtime:
 	}
 }
 
+func TestInstallCommandAcceptsAgentFlag(t *testing.T) {
+	restore := stubAWSProviderFactory()
+	defer restore()
+	restoreSourceArchive := stubSourceArchiveURL(t)
+	defer restoreSourceArchive()
+
+	originalBuildRuntimeBinary := runtimeinstall.BuildRuntimeBinaryFunc
+	runtimeinstall.BuildRuntimeBinaryFunc = func(ctx context.Context) (string, error) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "agenthub")
+		if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	defer func() { runtimeinstall.BuildRuntimeBinaryFunc = originalBuildRuntimeBinary }()
+
+	originalExecutor := newSSHExecutor
+	newSSHExecutor = func(cfg host.SSHConfig) host.Executor {
+		return fakeSSHExecutor{
+			results: map[string]host.CommandResult{
+				"true":          {},
+				"nvidia-smi -L": {Stdout: "GPU 0: demo"},
+				"docker info":   {Stdout: "Docker Engine"},
+				"docker info --format {{json .Runtimes}}":                                                {Stdout: `{"nvidia":{}}`},
+				"docker run --rm --gpus all --pull=never nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi": {Stdout: "NVIDIA-SMI"},
+				"sudo mkdir -p /opt/agenthub":                                                            {},
+				"chmod +x /opt/agenthub/install.sh":                                                      {},
+				"sh /opt/agenthub/install.sh /opt/agenthub/runtime.yaml":                                 {Stdout: "AgentHub runtime installation complete"},
+				"sudo mkdir -p /opt/agenthub/bin":                                                        {},
+				"sudo chown -R ubuntu:ubuntu /opt/agenthub":                                              {},
+				"sudo mv /opt/agenthub/agenthub.upload /opt/agenthub/bin/agenthub":                       {},
+				"chmod +x /opt/agenthub/bin/agenthub":                                                    {},
+				"sudo mv /opt/agenthub/agenthub.service /etc/systemd/system/agenthub.service":            {},
+				"sudo systemctl daemon-reload":                                                           {},
+				"sudo systemctl enable --now agenthub.service":                                           {},
+			},
+		}
+	}
+	defer func() { newSSHExecutor = originalExecutor }()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "demo.pem")
+	if err := os.WriteFile(keyPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("WriteFile(key) error = %v", err)
+	}
+	agentsDir := filepath.Join(dir, "agents")
+	configPath := filepath.Join(agentsDir, "alpha", "config.yaml")
+	if err := writeMinimalInstallConfig(configPath, keyPath); err != nil {
+		t.Fatalf("writeMinimalInstallConfig() error = %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "install", "--agent", "alpha", "--agents-dir", agentsDir, "--target", "i-0123456789abcdef0", "--working-dir", "/opt/agenthub", "--ssh-user", "ubuntu", "--ssh-key", keyPath}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "install workflow completed") {
+		t.Fatalf("stdout = %q, want install summary", got)
+	}
+	if !strings.Contains(got, "agenthub verify --config "+configPath) {
+		t.Fatalf("stdout = %q, want next step to use resolved config path", got)
+	}
+}
+
+func TestInstallCommandRejectsConfigAndAgent(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "--config", "agents/alpha/config.yaml", "install", "--agent", "alpha", "--target", "host"}
+
+	app := New()
+	cmd := newRootCommand(app)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually exclusive message", err)
+	}
+}
+
+func TestVerifyCommandAcceptsAgentFlag(t *testing.T) {
+	restore := stubAWSProviderFactory()
+	defer restore()
+
+	originalLocalExecutor := newLocalExecutor
+	newLocalExecutor = func() host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				switch {
+				case command == "true" && len(args) == 0:
+					return host.CommandResult{}, nil
+				case command == "nvidia-smi" && strings.Join(args, " ") == "-L":
+					return host.CommandResult{Stdout: "GPU 0: demo"}, nil
+				case command == "docker" && strings.Join(args, " ") == "info":
+					return host.CommandResult{Stdout: "Docker Engine"}, nil
+				case command == "test" && strings.Join(args, " ") == "-s /opt/agenthub/runtime.yaml":
+					return host.CommandResult{}, nil
+				case command == "cat" && strings.Join(args, " ") == "/opt/agenthub/runtime.yaml":
+					return host.CommandResult{Stdout: "use_nemoclaw: true\nnim_endpoint: http://localhost:11434\nmodel: llama3.2\n"}, nil
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc":
+					return host.CommandResult{Stdout: "ok"}, nil
+				default:
+					return host.CommandResult{}, errors.New("unexpected command: " + command + " " + strings.Join(args, " "))
+				}
+			},
+		}
+	}
+	defer func() { newLocalExecutor = originalLocalExecutor }()
+
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "agents")
+	configPath := filepath.Join(agentsDir, "alpha", "config.yaml")
+	if err := writeMinimalAgentConfig(configPath); err != nil {
+		t.Fatalf("writeMinimalAgentConfig() error = %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "verify", "--agent", "alpha", "--agents-dir", agentsDir}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	got := stdout.String()
+	for _, fragment := range []string{"verification summary", "gpu visibility: PASS", "all required checks passed"} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("stdout = %q, want %q", got, fragment)
+		}
+	}
+	_ = configPath
+}
+
+func TestVerifyCommandStillWorksWithoutConfigSelection(t *testing.T) {
+	restore := stubAWSProviderFactory()
+	defer restore()
+
+	originalLocalExecutor := newLocalExecutor
+	newLocalExecutor = func() host.Executor {
+		return flexibleExecutor{
+			run: func(command string, args ...string) (host.CommandResult, error) {
+				switch {
+				case command == "true" && len(args) == 0:
+					return host.CommandResult{}, nil
+				case command == "nvidia-smi" && strings.Join(args, " ") == "-L":
+					return host.CommandResult{Stdout: "GPU 0: demo"}, nil
+				case command == "docker" && strings.Join(args, " ") == "info":
+					return host.CommandResult{Stdout: "Docker Engine"}, nil
+				case command == "test" && strings.Join(args, " ") == "-s /opt/agenthub/runtime.yaml":
+					return host.CommandResult{}, nil
+				case command == "cat" && strings.Join(args, " ") == "/opt/agenthub/runtime.yaml":
+					return host.CommandResult{Stdout: "use_nemoclaw: true\nnim_endpoint: http://localhost:11434\nmodel: llama3.2\n"}, nil
+				case command == "sh" && len(args) >= 2 && args[0] == "-lc":
+					return host.CommandResult{Stdout: "ok"}, nil
+				default:
+					return host.CommandResult{}, errors.New("unexpected command: " + command + " " + strings.Join(args, " "))
+				}
+			},
+		}
+	}
+	defer func() { newLocalExecutor = originalLocalExecutor }()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "verify"}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "verification summary") {
+		t.Fatalf("stdout = %q, want verification summary", got)
+	}
+}
+
+func writeMinimalAgentConfig(path string) error {
+	return writeMinimalInstallConfig(path, "")
+}
+
+func writeMinimalInstallConfig(path, keyPath string) error {
+	keyBlock := ""
+	if strings.TrimSpace(keyPath) != "" {
+		keyBlock = "\n  private_key_path: " + keyPath
+	}
+	content := `
+platform:
+  name: aws
+region:
+  name: us-east-1
+ssh:
+  key_name: demo-key` + keyBlock + `
+  cidr: 203.0.113.0/24
+  user: ubuntu
+instance:
+  type: g5.xlarge
+  disk_size_gb: 40
+  network_mode: public
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+sandbox:
+  enabled: true
+  network_mode: public
+  use_nemoclaw: false
+`
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o600)
+}
+
 func TestLogsCommandFetchesRuntimeAndIntegrationLogs(t *testing.T) {
 	restore := stubAWSProviderFactory()
 	defer restore()

--- a/internal/app/slack.go
+++ b/internal/app/slack.go
@@ -23,21 +23,25 @@ func newSlackServeCommand(app *App) *cobra.Command {
 	var allowedChannels []string
 	var requestTimeout time.Duration
 	var agentsDir string
+	var agentName string
 	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run the Slack Socket Mode adapter",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath := strings.TrimSpace(app.opts.ConfigPath)
-			if configPath == "" {
-				session := prompt.NewSession(cmd.InOrStdin(), cmd.OutOrStdout())
-				selectedConfigPath, err := selectAgentConfigPath(session, agentsDir)
-				if err != nil {
-					return err
-				}
-				configPath = selectedConfigPath
+			configPath, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+				ConfigPath:       app.opts.ConfigPath,
+				AgentName:        agentName,
+				AgentsDir:        agentsDir,
+				Session:          prompt.NewSession(cmd.InOrStdin(), cmd.OutOrStdout()),
+				AllowInteractive: true,
+				RequireConfig:    true,
+			})
+			if err != nil {
+				return err
 			}
+			app.opts.ConfigPath = configPath
 			agentCfg, err := config.Load(configPath)
 			if err != nil {
 				return err
@@ -94,6 +98,7 @@ func newSlackServeCommand(app *App) *cobra.Command {
 	cmd.Flags().StringVar(&botUserID, "bot-user-id", "", "Slack bot user id; defaults to SLACK_BOT_USER_ID or AuthTest")
 	cmd.Flags().StringSliceVar(&allowedChannels, "allowed-channel", nil, "channel ID allowed to trigger the bot; repeatable")
 	cmd.Flags().DurationVar(&requestTimeout, "request-timeout", 30*time.Second, "timeout for runtime requests")
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent name to resolve under the agents directory")
 	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enable Slack adapter debug logging")
 

--- a/internal/app/slack_deploy.go
+++ b/internal/app/slack_deploy.go
@@ -44,21 +44,25 @@ func newSlackDeployCommand(app *App) *cobra.Command {
 	var sshPort int
 	var workingDir string
 	var agentsDir string
+	var agentName string
 
 	cmd := &cobra.Command{
 		Use:     "deploy",
 		Short:   "Deploy the Slack adapter to a remote EC2 host",
 		GroupID: "integrations",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath := strings.TrimSpace(app.opts.ConfigPath)
-			if configPath == "" {
-				session := prompt.NewSession(cmd.InOrStdin(), cmd.OutOrStdout())
-				selectedConfigPath, err := selectAgentConfigPath(session, agentsDir)
-				if err != nil {
-					return err
-				}
-				configPath = selectedConfigPath
+			configPath, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+				ConfigPath:       app.opts.ConfigPath,
+				AgentName:        agentName,
+				AgentsDir:        agentsDir,
+				Session:          prompt.NewSession(cmd.InOrStdin(), cmd.OutOrStdout()),
+				AllowInteractive: true,
+				RequireConfig:    true,
+			})
+			if err != nil {
+				return err
 			}
+			app.opts.ConfigPath = configPath
 			agentCfg, err := config.Load(configPath)
 			if err != nil {
 				return err
@@ -123,6 +127,7 @@ func newSlackDeployCommand(app *App) *cobra.Command {
 	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key")
 	cmd.Flags().IntVar(&sshPort, "ssh-port", 22, "SSH port")
 	cmd.Flags().StringVar(&workingDir, "working-dir", "/opt/agenthub", "remote working directory")
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent name to resolve under the agents directory")
 	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
 	return cmd
 }

--- a/internal/app/slack_deploy_test.go
+++ b/internal/app/slack_deploy_test.go
@@ -319,9 +319,10 @@ infra:
 	defer func() { os.Args = oldArgs }()
 	os.Args = []string{
 		"agenthub",
-		"--config", configPath,
 		"slack",
 		"deploy",
+		"--agent", "alpha",
+		"--agents-dir", agentsDir,
 		"--ssh-user", "ubuntu",
 		"--ssh-key", keyPath,
 		"--working-dir", "/opt/agenthub",

--- a/internal/app/slack_test.go
+++ b/internal/app/slack_test.go
@@ -90,3 +90,60 @@ func TestSlackServeLoadsAgentEnvFile(t *testing.T) {
 		t.Fatalf("allowed channels = %#v, want agent env values", got.AllowedChannels)
 	}
 }
+
+func TestSlackServeAcceptsAgentFlag(t *testing.T) {
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "agents")
+	configPath := filepath.Join(agentsDir, "alpha", "config.yaml")
+	envPath := filepath.Join(agentsDir, "alpha", ".env")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(strings.Join([]string{
+		"runtime:",
+		"  provider: codex",
+		"  model: codex-pro",
+		"  endpoint: http://localhost:11434",
+		"slack:",
+		"  runtime_url: http://agent-runtime.example.com",
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte(strings.Join([]string{
+		"SLACK_BOT_TOKEN=xoxb-agent-token",
+		"SLACK_APP_TOKEN=xapp-agent-token",
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile(env) error = %v", err)
+	}
+
+	originalRunSlackAdapter := runSlackAdapter
+	defer func() { runSlackAdapter = originalRunSlackAdapter }()
+
+	var got slackbot.Config
+	runSlackAdapter = func(ctx context.Context, cfg slackbot.Config, out io.Writer) error {
+		got = cfg
+		return nil
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "slack", "serve", "--agent", "alpha", "--agents-dir", agentsDir}
+
+	app := New()
+	cmd := newRootCommand(app)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got.BotToken != "xoxb-agent-token" || got.AppToken != "xapp-agent-token" {
+		t.Fatalf("slack config = %#v, want agent env values", got)
+	}
+	if got.RuntimeURL != "http://agent-runtime.example.com" {
+		t.Fatalf("runtime url = %q, want agent runtime url", got.RuntimeURL)
+	}
+}

--- a/internal/app/verify.go
+++ b/internal/app/verify.go
@@ -16,16 +16,26 @@ func newVerifyCommand(app *App) *cobra.Command {
 	var sshKey string
 	var sshPort int
 	var runtimeConfigPath string
+	var agentName string
+	var agentsDir string
 
 	cmd := &cobra.Command{
 		Use:     "verify",
 		Short:   "Verify the runtime environment",
 		GroupID: "runtime",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := resolveAgentConfigPath(agentConfigResolutionOptions{
+				ConfigPath: app.opts.ConfigPath,
+				AgentName:  agentName,
+				AgentsDir:  agentsDir,
+			})
+			if err != nil {
+				return err
+			}
+			app.opts.ConfigPath = configPath
 			var cfg *config.Config
-			var err error
-			if strings.TrimSpace(app.opts.ConfigPath) != "" {
-				cfg, err = config.Load(app.opts.ConfigPath)
+			if strings.TrimSpace(configPath) != "" {
+				cfg, err = config.Load(configPath)
 				if err != nil {
 					return err
 				}
@@ -74,5 +84,7 @@ func newVerifyCommand(app *App) *cobra.Command {
 	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key")
 	cmd.Flags().IntVar(&sshPort, "ssh-port", 22, "SSH port")
 	cmd.Flags().StringVar(&runtimeConfigPath, "runtime-config", "/opt/agenthub/runtime.yaml", "path to the runtime config on the target host")
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent name to resolve under the agents directory")
+	cmd.Flags().StringVar(&agentsDir, "agents-dir", "agents", "path to the agents directory")
 	return cmd
 }


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #54 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

Implemented on feat/non-interactive-agent-selection and verified. The CLI now uses a shared agent-config resolver in internal/app/agent_selection.go:22, and the planned commands now accept --agent with consistent resolution/error handling in internal/app/create.go:37, internal/app/install.go:32, internal/app/verify.go:27, internal/app/slack.go:33, and internal/app/slack_deploy.go:54. Docs/examples were updated in README.md:37 and doc/cli-usage.md:16. 

Coverage now includes the resolver and command-level --agent paths in internal/app/ agent_selection_test.go:8, internal/app/root_test.go:1890, internal/app/ slack_test.go:94, and internal/app/slack_deploy_test.go:252.
<!-- close -->