### PR TITLE
Require GitHub Connectivity for Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Run the interactive setup:
 agenthub init
 ```
 
+`agenthub init` now requires GitHub connectivity for deployable agents and guides you through GitHub App auth by default. User-token auth remains available for personal or development environments.
+
 Provision from a config file:
 
 ```bash

--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -25,6 +25,8 @@ agenthub create --config agents/alpha/config.yaml
 Notes:
 
 - `agenthub init` and `agenthub create` both require a usable AWS profile.
+- Deployed agents require GitHub connectivity. `agenthub init` now configures GitHub auth as a required step, and `agenthub create` refuses to proceed without valid GitHub deployment auth.
+- GitHub App auth is the recommended default for shared or production environments. `github.auth_mode=user` remains available for personal or development use.
 - Pass `--profile` or set `AWS_PROFILE` before running them.
 - If only one AWS profile is discovered locally, `agenthub` auto-selects it instead of prompting.
 - `agenthub init` writes public networking so the generated config is ready for `agenthub create`.

--- a/doc/manual-bootstrap-commands.md
+++ b/doc/manual-bootstrap-commands.md
@@ -29,6 +29,8 @@ If you omit it and run interactively, the CLI will prompt you to choose a profil
 
 This command reads the YAML config, resolves the SSH public key, stages the current working tree as a bootstrap archive, and writes Terraform-compatible `terraform.tfvars` variables.
 If GitHub App auth is configured, it carries the project-owned Secrets Manager ARN into Terraform so the EC2 instance role can read the private key secret at runtime.
+GitHub connectivity is required for deployed agents, so `agenthub infra tfvars` and `agenthub create` now fail fast if the config does not include valid GitHub deployment auth.
+Prefer GitHub App auth for shared or production environments. User-token auth is still supported as an explicit personal/development fallback.
 The generated file includes deploy-time values such as `aws_profile`, `runtime_port`, `runtime_cidr`, and `source_archive_url`, so Terraform can create the EC2 instance and leave runtime installation to the SSH-based `install` stage.
 Treat it as a deploy helper rather than a pure formatter: it depends on a usable SSH private key path, a resolvable AWS profile, the current git worktree state, and a GitHub App secret ARN if you want the host to clone private repositories.
 

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -53,6 +53,9 @@ func newCreateCommand(app *App) *cobra.Command {
 			if err := config.Validate(cfg); err != nil {
 				return err
 			}
+			if err := validateDeploymentConfig(cmd.OutOrStdout(), cfg); err != nil {
+				return err
+			}
 			profile, err := selectCreateAWSProfile(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout(), firstNonEmpty(app.opts.Profile, cfg.Infra.AWSProfile))
 			if err != nil {
 				return err

--- a/internal/app/deployment_validation.go
+++ b/internal/app/deployment_validation.go
@@ -1,0 +1,21 @@
+package app
+
+import (
+	"io"
+
+	"agenthub/internal/config"
+)
+
+func validateDeploymentConfig(out io.Writer, cfg *config.Config) error {
+	if err := config.ValidateDeployment(cfg); err != nil {
+		return wrapUserFacingError(
+			"deployment validation failed",
+			err,
+			"GitHub connectivity is required for deployment",
+			"configure GitHub App auth and rerun "+commandRef(out, "agenthub", "init"),
+			"use "+commandRef(out, "agenthub", "config", "secret", "update")+" if you need to add or repair github.* settings in an existing config",
+			"use github.auth_mode=user only for personal or development environments",
+		)
+	}
+	return nil
+}

--- a/internal/app/infra_tfvars.go
+++ b/internal/app/infra_tfvars.go
@@ -39,6 +39,9 @@ This command resolves the active AWS profile, derives the SSH public key from th
 			if err := validateInfraConfig(cfg); err != nil {
 				return err
 			}
+			if err := validateDeploymentConfig(cmd.OutOrStdout(), cfg); err != nil {
+				return err
+			}
 
 			profile, err := selectAWSProfile(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout(), app.opts.Profile)
 			if err != nil {

--- a/internal/app/infra_tfvars_test.go
+++ b/internal/app/infra_tfvars_test.go
@@ -235,6 +235,10 @@ sandbox:
   enabled: true
   network_mode: public
 github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:agenthub/github-app-private-key
   ssh_key_secret_arn: arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:agenthub/github-ssh-key
 ssh:
   key_name: demo-key
@@ -303,6 +307,11 @@ runtime:
 sandbox:
   enabled: true
   network_mode: public
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:agenthub/github-app-private-key
 ssh:
   key_name: demo-key
   private_key_path: `+keyPath+`

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -24,6 +24,15 @@ func stubGitHubSSHSetup(t *testing.T) {
 	t.Cleanup(func() { deriveSSHPublicKeyFunc = originalDerive })
 }
 
+func defaultGitHubAppInitInput() []string {
+	return []string{
+		"", // accept default GitHub App auth
+		"123456",
+		"789012",
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
+	}
+}
+
 func TestInitWritesConfigFile(t *testing.T) {
 	restore := stubAWSProviderFactory()
 	defer restore()
@@ -44,7 +53,10 @@ func TestInitWritesConfigFile(t *testing.T) {
 		"/tmp/demo.pem",          // ssh private key
 		"203.0.113.0/24",         // ssh cidr
 		"ubuntu",                 // ssh user
-		"",                       // authenticate Git with your GitHub credentials
+		"",                       // accept default GitHub App auth
+		"123456",                 // GitHub App ID
+		"789012",                 // GitHub installation ID
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
 		"http://localhost:11434", // endpoint
@@ -89,6 +101,10 @@ func TestInitWritesConfigFile(t *testing.T) {
 		"use_nemoclaw: true",
 		"provider: codex",
 		"endpoint: http://localhost:11434",
+		"auth_mode: app",
+		`app_id: "123456"`,
+		`installation_id: "789012"`,
+		"private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 	} {
 		if !strings.Contains(body, fragment) {
 			t.Fatalf("config file %q missing %q", body, fragment)
@@ -138,7 +154,10 @@ func TestInitUsesDefaultAgentNameWhenBlank(t *testing.T) {
 		"/tmp/demo.pem",          // ssh private key
 		"203.0.113.0/24",         // ssh cidr
 		"ubuntu",                 // ssh user
-		"",                       // authenticate Git with your GitHub credentials
+		"",                       // accept default GitHub App auth
+		"123456",                 // GitHub App ID
+		"789012",                 // GitHub installation ID
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
 		"http://localhost:11434", // endpoint
@@ -193,7 +212,10 @@ func TestInitSupportsCPUComputeMode(t *testing.T) {
 		"/tmp/demo.pem",
 		"203.0.113.0/24",
 		"ubuntu",
-		"",                       // skip GitHub access
+		"",                       // accept default GitHub App auth
+		"123456",
+		"789012",
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
 		"http://localhost:11434", // endpoint
@@ -255,7 +277,10 @@ func TestInitSupportsNonAWSPlatformScaffold(t *testing.T) {
 		"/tmp/demo.pem",          // ssh private key
 		"203.0.113.0/24",         // ssh cidr
 		"ubuntu",                 // ssh user
-		"",                       // authenticate Git with your GitHub credentials
+		"",                       // accept default GitHub App auth
+		"123456",                 // GitHub App ID
+		"789012",                 // GitHub installation ID
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
 		"http://localhost:11434", // endpoint
@@ -360,6 +385,10 @@ sandbox:
 		"/tmp/demo.pem",
 		"203.0.113.0/24",
 		"",
+		"",
+		"123456",
+		"789012",
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",
 		"1",
 		"http://localhost:11434",
@@ -419,7 +448,10 @@ func TestInitContinuesWhenAWSAuthCheckIsPermissionDenied(t *testing.T) {
 		"/tmp/demo.pem",          // ssh private key
 		"203.0.113.0/24",         // ssh cidr
 		"ubuntu",                 // ssh user
-		"",                       // authenticate Git with your GitHub credentials
+		"",                       // accept default GitHub App auth
+		"123456",                 // GitHub App ID
+		"789012",                 // GitHub installation ID
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
 		"http://localhost:11434", // endpoint
@@ -475,7 +507,10 @@ func TestInitContinuesWhenAWSAuthCheckFailsAtSTS(t *testing.T) {
 		"/tmp/demo.pem",          // ssh private key
 		"203.0.113.0/24",         // ssh cidr
 		"ubuntu",                 // ssh user
-		"",                       // authenticate Git with your GitHub credentials
+		"",                       // accept default GitHub App auth
+		"123456",                 // GitHub App ID
+		"789012",                 // GitHub installation ID
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
 		"http://localhost:11434", // endpoint
@@ -531,7 +566,10 @@ func TestInitFallsBackWhenAWSImageLookupIsPermissionDenied(t *testing.T) {
 		"/tmp/demo.pem",          // ssh private key
 		"203.0.113.0/24",         // ssh cidr
 		"ubuntu",                 // ssh user
-		"",                       // authenticate Git with your GitHub credentials
+		"",                       // accept default GitHub App auth
+		"123456",                 // GitHub App ID
+		"789012",                 // GitHub installation ID
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
 		"http://localhost:11434", // endpoint

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -24,15 +24,6 @@ func stubGitHubSSHSetup(t *testing.T) {
 	t.Cleanup(func() { deriveSSHPublicKeyFunc = originalDerive })
 }
 
-func defaultGitHubAppInitInput() []string {
-	return []string{
-		"", // accept default GitHub App auth
-		"123456",
-		"789012",
-		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
-	}
-}
-
 func TestInitWritesConfigFile(t *testing.T) {
 	restore := stubAWSProviderFactory()
 	defer restore()
@@ -42,20 +33,20 @@ func TestInitWritesConfigFile(t *testing.T) {
 	agentsDir := filepath.Join(dir, "agents")
 	configPath := filepath.Join(agentsDir, "alpha", "config.yaml")
 	input := strings.Join([]string{
-		"alpha",                  // agent name
-		"1",                      // platform aws
-		"",                       // accept default GPU compute mode
-		"2",                      // region us-east-1
-		"",                       // accept default instance g5.xlarge
-		"1",                      // image ubuntu-24.04
-		"20",                     // disk size
-		"demo-key",               // ssh key pair name
-		"/tmp/demo.pem",          // ssh private key
-		"203.0.113.0/24",         // ssh cidr
-		"ubuntu",                 // ssh user
-		"",                       // accept default GitHub App auth
-		"123456",                 // GitHub App ID
-		"789012",                 // GitHub installation ID
+		"alpha",          // agent name
+		"1",              // platform aws
+		"",               // accept default GPU compute mode
+		"2",              // region us-east-1
+		"",               // accept default instance g5.xlarge
+		"1",              // image ubuntu-24.04
+		"20",             // disk size
+		"demo-key",       // ssh key pair name
+		"/tmp/demo.pem",  // ssh private key
+		"203.0.113.0/24", // ssh cidr
+		"ubuntu",         // ssh user
+		"",               // accept default GitHub App auth
+		"123456",         // GitHub App ID
+		"789012",         // GitHub installation ID
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
@@ -143,20 +134,20 @@ func TestInitUsesDefaultAgentNameWhenBlank(t *testing.T) {
 	agentsDir := filepath.Join(dir, "agents")
 	configPath := filepath.Join(agentsDir, "default", "config.yaml")
 	input := strings.Join([]string{
-		"",                       // accept default agent name
-		"1",                      // platform aws
-		"",                       // accept default GPU compute mode
-		"2",                      // region us-east-1
-		"",                       // accept default instance g5.xlarge
-		"1",                      // image ubuntu-24.04
-		"20",                     // disk size
-		"demo-key",               // ssh key pair name
-		"/tmp/demo.pem",          // ssh private key
-		"203.0.113.0/24",         // ssh cidr
-		"ubuntu",                 // ssh user
-		"",                       // accept default GitHub App auth
-		"123456",                 // GitHub App ID
-		"789012",                 // GitHub installation ID
+		"",               // accept default agent name
+		"1",              // platform aws
+		"",               // accept default GPU compute mode
+		"2",              // region us-east-1
+		"",               // accept default instance g5.xlarge
+		"1",              // image ubuntu-24.04
+		"20",             // disk size
+		"demo-key",       // ssh key pair name
+		"/tmp/demo.pem",  // ssh private key
+		"203.0.113.0/24", // ssh cidr
+		"ubuntu",         // ssh user
+		"",               // accept default GitHub App auth
+		"123456",         // GitHub App ID
+		"789012",         // GitHub installation ID
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
@@ -212,7 +203,7 @@ func TestInitSupportsCPUComputeMode(t *testing.T) {
 		"/tmp/demo.pem",
 		"203.0.113.0/24",
 		"ubuntu",
-		"",                       // accept default GitHub App auth
+		"", // accept default GitHub App auth
 		"123456",
 		"789012",
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
@@ -266,20 +257,20 @@ func TestInitSupportsNonAWSPlatformScaffold(t *testing.T) {
 	agentsDir := filepath.Join(dir, "agents")
 	configPath := filepath.Join(agentsDir, "alpha", "config.yaml")
 	input := strings.Join([]string{
-		"alpha",                  // agent name
-		"2",                      // gcp
-		"",                       // accept default GPU compute mode
-		"",                       // accept default region
-		"",                       // accept default instance type
-		"1",                      // image Ubuntu 22.04 LTS
-		"20",                     // disk size
-		"demo-key",               // ssh key pair name
-		"/tmp/demo.pem",          // ssh private key
-		"203.0.113.0/24",         // ssh cidr
-		"ubuntu",                 // ssh user
-		"",                       // accept default GitHub App auth
-		"123456",                 // GitHub App ID
-		"789012",                 // GitHub installation ID
+		"alpha",          // agent name
+		"2",              // gcp
+		"",               // accept default GPU compute mode
+		"",               // accept default region
+		"",               // accept default instance type
+		"1",              // image Ubuntu 22.04 LTS
+		"20",             // disk size
+		"demo-key",       // ssh key pair name
+		"/tmp/demo.pem",  // ssh private key
+		"203.0.113.0/24", // ssh cidr
+		"ubuntu",         // ssh user
+		"",               // accept default GitHub App auth
+		"123456",         // GitHub App ID
+		"789012",         // GitHub installation ID
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
@@ -438,19 +429,19 @@ func TestInitContinuesWhenAWSAuthCheckIsPermissionDenied(t *testing.T) {
 	agentsDir := filepath.Join(dir, "agents")
 	input := strings.Join([]string{
 		"alpha",
-		"1",                      // platform aws
-		"",                       // accept default GPU compute mode
-		"2",                      // region us-east-1
-		"",                       // accept default instance g5.xlarge
-		"1",                      // image ubuntu-24.04
-		"20",                     // disk size
-		"demo-key",               // ssh key pair name
-		"/tmp/demo.pem",          // ssh private key
-		"203.0.113.0/24",         // ssh cidr
-		"ubuntu",                 // ssh user
-		"",                       // accept default GitHub App auth
-		"123456",                 // GitHub App ID
-		"789012",                 // GitHub installation ID
+		"1",              // platform aws
+		"",               // accept default GPU compute mode
+		"2",              // region us-east-1
+		"",               // accept default instance g5.xlarge
+		"1",              // image ubuntu-24.04
+		"20",             // disk size
+		"demo-key",       // ssh key pair name
+		"/tmp/demo.pem",  // ssh private key
+		"203.0.113.0/24", // ssh cidr
+		"ubuntu",         // ssh user
+		"",               // accept default GitHub App auth
+		"123456",         // GitHub App ID
+		"789012",         // GitHub installation ID
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
@@ -497,19 +488,19 @@ func TestInitContinuesWhenAWSAuthCheckFailsAtSTS(t *testing.T) {
 	agentsDir := filepath.Join(dir, "agents")
 	input := strings.Join([]string{
 		"alpha",
-		"1",                      // platform aws
-		"",                       // accept default GPU compute mode
-		"2",                      // region us-east-1
-		"",                       // accept default instance g5.xlarge
-		"1",                      // image ubuntu-24.04
-		"20",                     // disk size
-		"demo-key",               // ssh key pair name
-		"/tmp/demo.pem",          // ssh private key
-		"203.0.113.0/24",         // ssh cidr
-		"ubuntu",                 // ssh user
-		"",                       // accept default GitHub App auth
-		"123456",                 // GitHub App ID
-		"789012",                 // GitHub installation ID
+		"1",              // platform aws
+		"",               // accept default GPU compute mode
+		"2",              // region us-east-1
+		"",               // accept default instance g5.xlarge
+		"1",              // image ubuntu-24.04
+		"20",             // disk size
+		"demo-key",       // ssh key pair name
+		"/tmp/demo.pem",  // ssh private key
+		"203.0.113.0/24", // ssh cidr
+		"ubuntu",         // ssh user
+		"",               // accept default GitHub App auth
+		"123456",         // GitHub App ID
+		"789012",         // GitHub installation ID
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex
@@ -556,19 +547,19 @@ func TestInitFallsBackWhenAWSImageLookupIsPermissionDenied(t *testing.T) {
 	agentsDir := filepath.Join(dir, "agents")
 	input := strings.Join([]string{
 		"alpha",
-		"1",                      // platform aws
-		"",                       // accept default GPU compute mode
-		"2",                      // region us-east-1
-		"",                       // accept default instance g5.xlarge
-		"1",                      // image fallback selection
-		"20",                     // disk size
-		"demo-key",               // ssh key pair name
-		"/tmp/demo.pem",          // ssh private key
-		"203.0.113.0/24",         // ssh cidr
-		"ubuntu",                 // ssh user
-		"",                       // accept default GitHub App auth
-		"123456",                 // GitHub App ID
-		"789012",                 // GitHub installation ID
+		"1",              // platform aws
+		"",               // accept default GPU compute mode
+		"2",              // region us-east-1
+		"",               // accept default instance g5.xlarge
+		"1",              // image fallback selection
+		"20",             // disk size
+		"demo-key",       // ssh key pair name
+		"/tmp/demo.pem",  // ssh private key
+		"203.0.113.0/24", // ssh cidr
+		"ubuntu",         // ssh user
+		"",               // accept default GitHub App auth
+		"123456",         // GitHub App ID
+		"789012",         // GitHub installation ID
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
 		"y",                      // use NemoClaw
 		"1",                      // provider codex

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -371,7 +371,6 @@ sandbox:
 		"",  // accept default instance g5.xlarge
 		"1", // image
 		"20",
-		"",
 		"demo-key",
 		"/tmp/demo.pem",
 		"203.0.113.0/24",

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -185,6 +185,9 @@ func newInitCommand(app *App) *cobra.Command {
 			if err := config.Validate(cfg); err != nil {
 				return err
 			}
+			if err := validateDeploymentConfig(cmd.OutOrStdout(), cfg); err != nil {
+				return err
+			}
 			cfg.Infra.AWSProfile = strings.TrimSpace(wizard.AWSProfile)
 
 			agentName := strings.TrimSpace(wizard.AgentName)

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -116,6 +116,97 @@ runtime:
 	}
 }
 
+func TestCreateCommandFailsWhenGitHubDeploymentAuthIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "default", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+instance:
+  type: t3.medium
+  disk_size_gb: 20
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+sandbox:
+  enabled: true
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "create", "--config", path}
+
+	app := New()
+	cmd := newRootCommand(app)
+	cmd.SetIn(strings.NewReader(""))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "deployment validation failed") || !strings.Contains(got, "GitHub connectivity is required for deployment") {
+		t.Fatalf("error = %q, want deployment GitHub validation failure", got)
+	}
+}
+
+func TestInfraTFVarsCommandFailsWhenGitHubDeploymentAuthIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agents", "default", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeConfig(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+instance:
+  type: t3.medium
+  disk_size_gb: 20
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  model: llama3.2
+sandbox:
+  enabled: true
+ssh:
+  key_name: demo-key
+  private_key_path: /tmp/demo.pem
+  cidr: 203.0.113.0/24
+  user: ubuntu
+`)
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"agenthub", "infra", "tfvars", "--config", path}
+
+	app := New()
+	cmd := newRootCommand(app)
+	cmd.SetIn(strings.NewReader(""))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "deployment validation failed") || !strings.Contains(got, "GitHub connectivity is required for deployment") {
+		t.Fatalf("error = %q, want deployment GitHub validation failure", got)
+	}
+}
+
 func TestConfigUpdateCommandAppliesTypedUpdates(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agents", "default", "config.yaml")

--- a/internal/app/root_test.go
+++ b/internal/app/root_test.go
@@ -1468,6 +1468,11 @@ runtime:
   model: llama3.2
 sandbox:
   network_mode: public
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 `)
 
 	oldArgs := os.Args
@@ -2799,6 +2804,11 @@ sandbox:
   enabled: true
   network_mode: public
   use_nemoclaw: true
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 `)
 
 	oldArgs := os.Args
@@ -2957,6 +2967,11 @@ sandbox:
   enabled: true
   network_mode: public
   use_nemoclaw: true
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 `)
 	writeConfig(t, filepath.Join(agentsDir, "beta", "config.yaml"), `
 platform:
@@ -2984,6 +2999,11 @@ sandbox:
   enabled: true
   network_mode: public
   use_nemoclaw: true
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 `)
 
 	oldArgs := os.Args
@@ -3141,6 +3161,11 @@ sandbox:
   enabled: true
   network_mode: public
   use_nemoclaw: true
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 `)
 
 	oldArgs := os.Args
@@ -3280,6 +3305,11 @@ sandbox:
   enabled: true
   network_mode: public
   use_nemoclaw: true
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 `)
 
 	oldArgs := os.Args
@@ -3425,6 +3455,11 @@ sandbox:
   enabled: true
   network_mode: public
   use_nemoclaw: true
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 `)
 
 	oldArgs := os.Args
@@ -3512,6 +3547,11 @@ sandbox:
   enabled: true
   network_mode: public
   use_nemoclaw: true
+github:
+  auth_mode: app
+  app_id: "123456"
+  installation_id: "789012"
+  private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key
 infra:
   aws_profile: sso-dev
 `)
@@ -3845,6 +3885,14 @@ func defaultFlexibleCommand(command string, args ...string) (host.CommandResult,
 		return host.CommandResult{Stdout: "NVIDIA-SMI"}, true
 	case key == "nvidia-smi -L":
 		return host.CommandResult{Stdout: "GPU 0: demo"}, true
+	case key == "git --version":
+		return host.CommandResult{Stdout: "git version 2.0.0"}, true
+	case strings.HasPrefix(key, "git config --global credential.helper "):
+		return host.CommandResult{}, true
+	case key == "git config --global url.https://github.com/.insteadOf git@github.com:":
+		return host.CommandResult{}, true
+	case key == "git config --global url.https://github.com/.insteadOf ssh://git@github.com/":
+		return host.CommandResult{}, true
 	case command == "sudo" && len(args) >= 2 && args[0] == "mkdir" && args[1] == "-p":
 		return host.CommandResult{}, true
 	case command == "sudo" && len(args) >= 2 && args[0] == "chown" && args[1] == "-R":
@@ -3855,6 +3903,14 @@ func defaultFlexibleCommand(command string, args ...string) (host.CommandResult,
 		return host.CommandResult{}, true
 	case command == "sudo" && len(args) >= 1 && args[0] == "systemctl" && len(args) >= 2 && args[1] == "daemon-reload":
 		return host.CommandResult{}, true
+	case command == "sudo" && len(args) >= 3 && args[0] == "sh" && args[1] == "-lc":
+		script := args[2]
+		switch {
+		case strings.Contains(script, "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io"):
+			return host.CommandResult{Stdout: "docker installed"}, true
+		case strings.Contains(script, "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git"):
+			return host.CommandResult{Stdout: "git installed"}, true
+		}
 	case command == "chmod" && len(args) >= 2 && args[0] == "+x":
 		return host.CommandResult{}, true
 	case command == "chmod" && len(args) >= 2 && args[0] == "600":
@@ -3868,8 +3924,6 @@ func defaultFlexibleCommand(command string, args ...string) (host.CommandResult,
 			return host.CommandResult{Stdout: "agenthub systemd service is active"}, true
 		case strings.Contains(script, "docker ps --filter name='^/agenthub$'"):
 			return host.CommandResult{Stdout: "agenthub Up 10 seconds"}, true
-		case strings.Contains(script, "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io"):
-			return host.CommandResult{Stdout: "docker installed"}, true
 		}
 	case command == "sh" && len(args) >= 2 && strings.Contains(strings.Join(args, " "), "/opt/agenthub/install.sh /opt/agenthub/runtime.yaml"):
 		return host.CommandResult{Stdout: "AgentHub runtime installation complete"}, true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,12 +129,7 @@ func (e *ValidationError) Error() string {
 	if e == nil || len(e.Fields) == 0 {
 		return ""
 	}
-	var parts []string
-	for _, field := range e.Fields {
-		parts = append(parts, fmt.Sprintf("%s: %s", field.Field, field.Message))
-	}
-	sort.Strings(parts)
-	return "config validation failed: " + strings.Join(parts, "; ")
+	return formatValidationError("config validation failed", e.Fields)
 }
 
 func (e *ValidationError) Add(field, message string) {
@@ -227,42 +222,6 @@ func Validate(cfg *Config) error {
 	if provider := strings.TrimSpace(cfg.Runtime.Provider); provider != "" && !IsValidRuntimeProvider(provider) {
 		v.Add("runtime.provider", fmt.Sprintf("unsupported provider %q", provider))
 	}
-	if gh := cfg.GitHub; hasGitHubConfig(gh) {
-		explicitMode := strings.ToLower(strings.TrimSpace(gh.AuthMode))
-		if explicitMode != "" && explicitMode != GitHubAuthModeApp && explicitMode != GitHubAuthModeUser {
-			v.Add("github.auth_mode", fmt.Sprintf("unsupported GitHub auth mode %q", gh.AuthMode))
-			goto validateGitHubConfigDone
-		}
-		mode := GitHubAuthModeFor(gh)
-		switch mode {
-		case GitHubAuthModeUser:
-			if strings.TrimSpace(gh.TokenSecretARN) == "" {
-				v.Add("github.token_secret_arn", "is required when github user auth is configured")
-			} else if !strings.HasPrefix(strings.TrimSpace(gh.TokenSecretARN), "arn:") {
-				v.Add("github.token_secret_arn", "must be a Secrets Manager ARN")
-			}
-		case GitHubAuthModeApp:
-			if strings.TrimSpace(gh.AppID) == "" {
-				v.Add("github.app_id", "is required when github app auth is configured")
-			} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.AppID), 10, 64); err != nil {
-				v.Add("github.app_id", "must be a numeric GitHub App id")
-			}
-			if strings.TrimSpace(gh.InstallationID) == "" {
-				v.Add("github.installation_id", "is required when github app auth is configured")
-			} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.InstallationID), 10, 64); err != nil {
-				v.Add("github.installation_id", "must be a numeric GitHub installation id")
-			}
-			if strings.TrimSpace(gh.PrivateKeySecretARN) == "" {
-				v.Add("github.private_key_secret_arn", "is required when github app auth is configured")
-			} else if !strings.HasPrefix(strings.TrimSpace(gh.PrivateKeySecretARN), "arn:") {
-				v.Add("github.private_key_secret_arn", "must be a Secrets Manager ARN")
-			}
-		default:
-			// no-op: config.HasGitHubAuth may be true when the auth fields are
-			// incomplete, and the specific validation errors above will cover them.
-		}
-	}
-validateGitHubConfigDone:
 	if publicCIDR := strings.TrimSpace(cfg.Runtime.PublicCIDR); publicCIDR != "" {
 		if _, err := parseCIDRLike(publicCIDR); err != nil {
 			v.Add("runtime.public_cidr", err.Error())
@@ -288,6 +247,51 @@ validateGitHubConfigDone:
 	}
 
 	return v.OrNil()
+}
+
+func ValidateDeployment(cfg *Config) error {
+	if cfg == nil {
+		return errors.New("deployment validation failed: config is nil")
+	}
+
+	var v ValidationError
+	gh := cfg.GitHub
+	mode := GitHubAuthModeFor(gh)
+	switch mode {
+	case GitHubAuthModeUser:
+		if strings.TrimSpace(gh.TokenSecretARN) == "" {
+			v.Add("github.token_secret_arn", "is required for deployment when github.auth_mode=user")
+		} else if !strings.HasPrefix(strings.TrimSpace(gh.TokenSecretARN), "arn:") {
+			v.Add("github.token_secret_arn", "must be a Secrets Manager ARN")
+		}
+	case GitHubAuthModeApp:
+		if strings.TrimSpace(gh.AppID) == "" {
+			v.Add("github.app_id", "is required for deployment when github.auth_mode=app")
+		} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.AppID), 10, 64); err != nil {
+			v.Add("github.app_id", "must be a numeric GitHub App id")
+		}
+		if strings.TrimSpace(gh.InstallationID) == "" {
+			v.Add("github.installation_id", "is required for deployment when github.auth_mode=app")
+		} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.InstallationID), 10, 64); err != nil {
+			v.Add("github.installation_id", "must be a numeric GitHub installation id")
+		}
+		if strings.TrimSpace(gh.PrivateKeySecretARN) == "" {
+			v.Add("github.private_key_secret_arn", "is required for deployment when github.auth_mode=app")
+		} else if !strings.HasPrefix(strings.TrimSpace(gh.PrivateKeySecretARN), "arn:") {
+			v.Add("github.private_key_secret_arn", "must be a Secrets Manager ARN")
+		}
+	default:
+		if strings.TrimSpace(gh.AuthMode) != "" {
+			v.Add("github.auth_mode", fmt.Sprintf("GitHub connectivity is required for deployment; unsupported GitHub auth mode %q", gh.AuthMode))
+		} else {
+			v.Add("github.auth_mode", "GitHub connectivity is required for deployment; configure github.auth_mode=app (recommended) or github.auth_mode=user")
+		}
+	}
+
+	if len(v.Fields) == 0 {
+		return nil
+	}
+	return errors.New(formatValidationError("deployment validation failed", v.Fields))
 }
 
 func LoadAndValidate(path string) (*Config, error) {
@@ -448,4 +452,16 @@ func parseCIDRLike(value string) (string, error) {
 		return addr.String() + "/32", nil
 	}
 	return addr.String() + "/128", nil
+}
+
+func formatValidationError(prefix string, fields []FieldError) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(fields))
+	for _, field := range fields {
+		parts = append(parts, fmt.Sprintf("%s: %s", field.Field, field.Message))
+	}
+	sort.Strings(parts)
+	return prefix + ": " + strings.Join(parts, "; ")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -256,35 +256,41 @@ func ValidateDeployment(cfg *Config) error {
 
 	var v ValidationError
 	gh := cfg.GitHub
-	mode := GitHubAuthModeFor(gh)
-	switch mode {
-	case GitHubAuthModeUser:
-		if strings.TrimSpace(gh.TokenSecretARN) == "" {
-			v.Add("github.token_secret_arn", "is required for deployment when github.auth_mode=user")
-		} else if !strings.HasPrefix(strings.TrimSpace(gh.TokenSecretARN), "arn:") {
-			v.Add("github.token_secret_arn", "must be a Secrets Manager ARN")
+	explicitMode := strings.ToLower(strings.TrimSpace(gh.AuthMode))
+	if explicitMode != "" && explicitMode != GitHubAuthModeApp && explicitMode != GitHubAuthModeUser {
+		v.Add("github.auth_mode", fmt.Sprintf("unsupported GitHub auth mode %q", gh.AuthMode))
+	} else {
+		mode := explicitMode
+		if mode == "" {
+			mode = GitHubAuthModeFor(gh)
 		}
-	case GitHubAuthModeApp:
-		if strings.TrimSpace(gh.AppID) == "" {
-			v.Add("github.app_id", "is required for deployment when github.auth_mode=app")
-		} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.AppID), 10, 64); err != nil {
-			v.Add("github.app_id", "must be a numeric GitHub App id")
-		}
-		if strings.TrimSpace(gh.InstallationID) == "" {
-			v.Add("github.installation_id", "is required for deployment when github.auth_mode=app")
-		} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.InstallationID), 10, 64); err != nil {
-			v.Add("github.installation_id", "must be a numeric GitHub installation id")
-		}
-		if strings.TrimSpace(gh.PrivateKeySecretARN) == "" {
-			v.Add("github.private_key_secret_arn", "is required for deployment when github.auth_mode=app")
-		} else if !strings.HasPrefix(strings.TrimSpace(gh.PrivateKeySecretARN), "arn:") {
-			v.Add("github.private_key_secret_arn", "must be a Secrets Manager ARN")
-		}
-	default:
-		if strings.TrimSpace(gh.AuthMode) != "" {
-			v.Add("github.auth_mode", fmt.Sprintf("GitHub connectivity is required for deployment; unsupported GitHub auth mode %q", gh.AuthMode))
-		} else {
+		switch mode {
+		case "":
 			v.Add("github.auth_mode", "GitHub connectivity is required for deployment; configure github.auth_mode=app (recommended) or github.auth_mode=user")
+		case GitHubAuthModeUser:
+			if strings.TrimSpace(gh.TokenSecretARN) == "" {
+				v.Add("github.token_secret_arn", "is required for deployment when github.auth_mode=user")
+			} else if !strings.HasPrefix(strings.TrimSpace(gh.TokenSecretARN), "arn:") {
+				v.Add("github.token_secret_arn", "must be a Secrets Manager ARN")
+			}
+		case GitHubAuthModeApp:
+			if strings.TrimSpace(gh.AppID) == "" {
+				v.Add("github.app_id", "is required for deployment when github.auth_mode=app")
+			} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.AppID), 10, 64); err != nil {
+				v.Add("github.app_id", "must be a numeric GitHub App id")
+			}
+			if strings.TrimSpace(gh.InstallationID) == "" {
+				v.Add("github.installation_id", "is required for deployment when github.auth_mode=app")
+			} else if _, err := strconv.ParseInt(strings.TrimSpace(gh.InstallationID), 10, 64); err != nil {
+				v.Add("github.installation_id", "must be a numeric GitHub installation id")
+			}
+			if strings.TrimSpace(gh.PrivateKeySecretARN) == "" {
+				v.Add("github.private_key_secret_arn", "is required for deployment when github.auth_mode=app")
+			} else if !strings.HasPrefix(strings.TrimSpace(gh.PrivateKeySecretARN), "arn:") {
+				v.Add("github.private_key_secret_arn", "must be a Secrets Manager ARN")
+			}
+		default:
+			v.Add("github.auth_mode", fmt.Sprintf("unsupported GitHub auth mode %q", gh.AuthMode))
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,7 +73,7 @@ func TestValidateReportsReadableErrors(t *testing.T) {
 	}
 }
 
-func TestValidateRejectsIncompleteGitHubAuth(t *testing.T) {
+func TestValidateAllowsIncompleteGitHubAuth(t *testing.T) {
 	cfg := &Config{
 		Platform: PlatformConfig{Name: PlatformAWS},
 		Region:   RegionConfig{Name: "us-east-1"},
@@ -84,16 +84,12 @@ func TestValidateRejectsIncompleteGitHubAuth(t *testing.T) {
 		Sandbox:  SandboxConfig{Enabled: true},
 	}
 
-	err := Validate(cfg)
-	if err == nil {
-		t.Fatal("Validate() error = nil")
-	}
-	if got := err.Error(); !strings.Contains(got, "github.installation_id") || !strings.Contains(got, "github.private_key_secret_arn") {
-		t.Fatalf("Validate() error = %q, want github auth validation errors", got)
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("Validate() error = %v", err)
 	}
 }
 
-func TestValidateRejectsIncompleteGitHubUserAuth(t *testing.T) {
+func TestValidateAllowsIncompleteGitHubUserAuth(t *testing.T) {
 	cfg := &Config{
 		Platform: PlatformConfig{Name: PlatformAWS},
 		Region:   RegionConfig{Name: "us-east-1"},
@@ -104,12 +100,108 @@ func TestValidateRejectsIncompleteGitHubUserAuth(t *testing.T) {
 		Sandbox:  SandboxConfig{Enabled: true},
 	}
 
-	err := Validate(cfg)
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestValidateDeploymentRejectsMissingGitHubAuth(t *testing.T) {
+	cfg := &Config{
+		Platform: PlatformConfig{Name: PlatformAWS},
+		Region:   RegionConfig{Name: "us-east-1"},
+		Instance: InstanceConfig{Type: "t3.medium", DiskSizeGB: 20},
+		Image:    ImageConfig{Name: "ubuntu-24.04"},
+		Runtime:  RuntimeConfig{Endpoint: "http://localhost:11434", Model: "llama3.2"},
+		Sandbox:  SandboxConfig{Enabled: true},
+	}
+
+	err := ValidateDeployment(cfg)
 	if err == nil {
-		t.Fatal("Validate() error = nil")
+		t.Fatal("ValidateDeployment() error = nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "GitHub connectivity is required for deployment") || !strings.Contains(got, "github.auth_mode") {
+		t.Fatalf("ValidateDeployment() error = %q, want deployment GitHub validation error", got)
+	}
+}
+
+func TestValidateDeploymentRejectsIncompleteGitHubAuth(t *testing.T) {
+	cfg := &Config{
+		Platform: PlatformConfig{Name: PlatformAWS},
+		Region:   RegionConfig{Name: "us-east-1"},
+		Instance: InstanceConfig{Type: "t3.medium", DiskSizeGB: 20},
+		Image:    ImageConfig{Name: "ubuntu-24.04"},
+		Runtime:  RuntimeConfig{Endpoint: "http://localhost:11434", Model: "llama3.2"},
+		GitHub:   GitHubConfig{AuthMode: GitHubAuthModeApp, AppID: "123456"},
+		Sandbox:  SandboxConfig{Enabled: true},
+	}
+
+	err := ValidateDeployment(cfg)
+	if err == nil {
+		t.Fatal("ValidateDeployment() error = nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "github.installation_id") || !strings.Contains(got, "github.private_key_secret_arn") {
+		t.Fatalf("ValidateDeployment() error = %q, want github auth validation errors", got)
+	}
+}
+
+func TestValidateDeploymentRejectsIncompleteGitHubUserAuth(t *testing.T) {
+	cfg := &Config{
+		Platform: PlatformConfig{Name: PlatformAWS},
+		Region:   RegionConfig{Name: "us-east-1"},
+		Instance: InstanceConfig{Type: "t3.medium", DiskSizeGB: 20},
+		Image:    ImageConfig{Name: "ubuntu-24.04"},
+		Runtime:  RuntimeConfig{Endpoint: "http://localhost:11434", Model: "llama3.2"},
+		GitHub:   GitHubConfig{AuthMode: GitHubAuthModeUser},
+		Sandbox:  SandboxConfig{Enabled: true},
+	}
+
+	err := ValidateDeployment(cfg)
+	if err == nil {
+		t.Fatal("ValidateDeployment() error = nil")
 	}
 	if got := err.Error(); !strings.Contains(got, "github.token_secret_arn") {
-		t.Fatalf("Validate() error = %q, want github.token_secret_arn validation error", got)
+		t.Fatalf("ValidateDeployment() error = %q, want github.token_secret_arn validation error", got)
+	}
+}
+
+func TestValidateDeploymentRejectsUnsupportedGitHubAuthMode(t *testing.T) {
+	cfg := &Config{
+		Platform: PlatformConfig{Name: PlatformAWS},
+		Region:   RegionConfig{Name: "us-east-1"},
+		Instance: InstanceConfig{Type: "t3.medium", DiskSizeGB: 20},
+		Image:    ImageConfig{Name: "ubuntu-24.04"},
+		Runtime:  RuntimeConfig{Endpoint: "http://localhost:11434", Model: "llama3.2"},
+		GitHub:   GitHubConfig{AuthMode: "ssh"},
+		Sandbox:  SandboxConfig{Enabled: true},
+	}
+
+	err := ValidateDeployment(cfg)
+	if err == nil {
+		t.Fatal("ValidateDeployment() error = nil")
+	}
+	if got := err.Error(); !strings.Contains(got, `unsupported GitHub auth mode "ssh"`) {
+		t.Fatalf("ValidateDeployment() error = %q, want unsupported mode error", got)
+	}
+}
+
+func TestValidateDeploymentAcceptsValidGitHubAuth(t *testing.T) {
+	cfg := &Config{
+		Platform: PlatformConfig{Name: PlatformAWS},
+		Region:   RegionConfig{Name: "us-east-1"},
+		Instance: InstanceConfig{Type: "t3.medium", DiskSizeGB: 20},
+		Image:    ImageConfig{Name: "ubuntu-24.04"},
+		Runtime:  RuntimeConfig{Endpoint: "http://localhost:11434", Model: "llama3.2"},
+		GitHub: GitHubConfig{
+			AuthMode:            GitHubAuthModeApp,
+			AppID:               "123456",
+			InstallationID:      "789012",
+			PrivateKeySecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
+		},
+		Sandbox: SandboxConfig{Enabled: true},
+	}
+
+	if err := ValidateDeployment(cfg); err != nil {
+		t.Fatalf("ValidateDeployment() error = %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -184,6 +184,32 @@ func TestValidateDeploymentRejectsUnsupportedGitHubAuthMode(t *testing.T) {
 	}
 }
 
+func TestValidateDeploymentRejectsUnsupportedGitHubAuthModeEvenWithFallbackFields(t *testing.T) {
+	cfg := &Config{
+		Platform: PlatformConfig{Name: PlatformAWS},
+		Region:   RegionConfig{Name: "us-east-1"},
+		Instance: InstanceConfig{Type: "t3.medium", DiskSizeGB: 20},
+		Image:    ImageConfig{Name: "ubuntu-24.04"},
+		Runtime:  RuntimeConfig{Endpoint: "http://localhost:11434", Model: "llama3.2"},
+		GitHub: GitHubConfig{
+			AuthMode:            "ssh",
+			TokenSecretARN:      "arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-token",
+			AppID:               "123456",
+			InstallationID:      "789012",
+			PrivateKeySecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
+		},
+		Sandbox: SandboxConfig{Enabled: true},
+	}
+
+	err := ValidateDeployment(cfg)
+	if err == nil {
+		t.Fatal("ValidateDeployment() error = nil")
+	}
+	if got := err.Error(); !strings.Contains(got, `unsupported GitHub auth mode "ssh"`) {
+		t.Fatalf("ValidateDeployment() error = %q, want unsupported mode error", got)
+	}
+}
+
 func TestValidateDeploymentAcceptsValidGitHubAuth(t *testing.T) {
 	cfg := &Config{
 		Platform: PlatformConfig{Name: PlatformAWS},

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -236,49 +236,49 @@ func (w *Wizard) Run(ctx context.Context) (*config.Config, error) {
 	if err == nil && strings.TrimSpace(repoSlug) != "" {
 		w.logLine("Access", "!", fmt.Sprintf("detected GitHub repo candidate: %s", repoSlug))
 	}
+	w.logLine("Access", "⇒", "GitHub connectivity is required for deployed agents.")
+	w.logLine("Access", "⇒", "GitHub App auth is recommended for shared or production environments.")
 	githubCfg := config.GitHubConfig{}
 	if w.Existing != nil {
 		githubCfg = w.Existing.GitHub
 	}
-	connectGitHub, err := w.Prompter.Confirm("Configure GitHub access?", config.HasGitHubAuth(w.Existing))
+	defaultAuthMode := config.GitHubAuthModeFor(githubCfg)
+	if defaultAuthMode != config.GitHubAuthModeUser && defaultAuthMode != config.GitHubAuthModeApp {
+		defaultAuthMode = config.GitHubAuthModeApp
+	}
+	const (
+		githubAuthOptionApp  = "app (recommended for shared/production use)"
+		githubAuthOptionUser = "user (personal/development use)"
+	)
+	defaultAuthOption := githubAuthOptionApp
+	if defaultAuthMode == config.GitHubAuthModeUser {
+		defaultAuthOption = githubAuthOptionUser
+	}
+	authSelection, err := w.Prompter.Select("Select GitHub auth mode", []string{githubAuthOptionApp, githubAuthOptionUser}, defaultAuthOption)
 	if err != nil {
 		return nil, err
 	}
-	if connectGitHub {
-		defaultAuthMode := config.GitHubAuthModeFor(githubCfg)
-		if defaultAuthMode == "" {
-			if _, lookPathErr := exec.LookPath("gh"); lookPathErr == nil {
-				defaultAuthMode = config.GitHubAuthModeUser
-			} else {
-				defaultAuthMode = config.GitHubAuthModeApp
-			}
-		}
-		authMode, err := w.Prompter.Select("Select GitHub auth mode", []string{config.GitHubAuthModeUser, config.GitHubAuthModeApp}, defaultAuthMode)
+	switch authSelection {
+	case githubAuthOptionUser:
+		githubCfg, err = bootstrapGitHubUserAuth(ctx, w.AWSProfile, region, repoSlug)
 		if err != nil {
 			return nil, err
 		}
-		switch authMode {
-		case config.GitHubAuthModeUser:
-			githubCfg, err = bootstrapGitHubUserAuth(ctx, w.AWSProfile, region, repoSlug)
-			if err != nil {
-				return nil, err
-			}
-		case config.GitHubAuthModeApp:
-			githubCfg = config.GitHubConfig{AuthMode: config.GitHubAuthModeApp}
-			githubCfg.AppID, err = w.Prompter.Text("GitHub App ID", strings.TrimSpace(githubCfg.AppID))
-			if err != nil {
-				return nil, err
-			}
-			githubCfg.InstallationID, err = w.Prompter.Text("GitHub installation ID", strings.TrimSpace(githubCfg.InstallationID))
-			if err != nil {
-				return nil, err
-			}
-			githubCfg.PrivateKeySecretARN, err = w.Prompter.Text("GitHub private key secret ARN", strings.TrimSpace(githubCfg.PrivateKeySecretARN))
-			if err != nil {
-				return nil, err
-			}
-			githubCfg.TokenSecretARN = ""
+	default:
+		githubCfg.AuthMode = config.GitHubAuthModeApp
+		githubCfg.AppID, err = w.Prompter.Text("GitHub App ID", strings.TrimSpace(githubCfg.AppID))
+		if err != nil {
+			return nil, err
 		}
+		githubCfg.InstallationID, err = w.Prompter.Text("GitHub installation ID", strings.TrimSpace(githubCfg.InstallationID))
+		if err != nil {
+			return nil, err
+		}
+		githubCfg.PrivateKeySecretARN, err = w.Prompter.Text("GitHub private key secret ARN", strings.TrimSpace(githubCfg.PrivateKeySecretARN))
+		if err != nil {
+			return nil, err
+		}
+		githubCfg.TokenSecretARN = ""
 	}
 
 	useNemoClaw, err := w.Prompter.Confirm("Use NemoClaw", true)

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/netip"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"

--- a/internal/setup/wizard_test.go
+++ b/internal/setup/wizard_test.go
@@ -743,8 +743,7 @@ func TestWizardConfiguresGitHubUserAuthFromRepoOrigin(t *testing.T) {
 		"",
 		"",
 		"",
-		"y", // configure GitHub access
-		"1", // select user auth
+		"2", // select user auth
 		"y", // use NemoClaw
 		"1", // provider codex
 		"http://localhost:11434",
@@ -791,6 +790,62 @@ func TestWizardConfiguresGitHubUserAuthFromRepoOrigin(t *testing.T) {
 	// logLine writes "[Access] ! detected GitHub repo candidate: owner/repo"
 	if got := out.String(); !strings.Contains(got, "detected GitHub repo candidate: owner/repo") {
 		t.Fatalf("output = %q, want repo candidate", got)
+	}
+}
+
+func TestWizardDefaultsGitHubAuthToApp(t *testing.T) {
+	input := strings.Join([]string{
+		"alpha",
+		"1", // platform aws
+		"",  // accept default GPU compute mode
+		"1", // region
+		"",  // accept default instance type
+		"1", // base image
+		"20",
+		"",
+		"",
+		"",
+		"",
+		"", // accept default GitHub auth mode (app)
+		"123456",
+		"789012",
+		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
+		"y", // use NemoClaw
+		"1", // provider codex
+		"http://localhost:11434",
+		"y", // confirm summary
+	}, "\n") + "\n"
+
+	out := &bytes.Buffer{}
+	wizard := NewWizard(
+		prompt.NewSession(strings.NewReader(input), out),
+		out,
+		func(platform, computeClass string) provider.CloudProvider {
+			return fakeProvider{
+				regions: []string{"us-east-1", "us-west-2"},
+				report: provider.GPUQuotaReport{
+					Region:          "us-east-1",
+					InstanceFamily:  "g5",
+					LikelyCreatable: true,
+				},
+			}
+		},
+		&config.Config{},
+	)
+	wizard.AWSProfile = "sso-dev"
+
+	cfg, err := wizard.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if cfg.GitHub.AuthMode != config.GitHubAuthModeApp {
+		t.Fatalf("GitHub.AuthMode = %q, want %q", cfg.GitHub.AuthMode, config.GitHubAuthModeApp)
+	}
+	if cfg.GitHub.AppID != "123456" || cfg.GitHub.InstallationID != "789012" {
+		t.Fatalf("GitHub app config = %#v, want populated app fields", cfg.GitHub)
+	}
+	if got := out.String(); !strings.Contains(got, "GitHub connectivity is required for deployed agents.") {
+		t.Fatalf("output = %q, want required GitHub messaging", got)
 	}
 }
 


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #111 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

The main changes are in internal/config/config.go:171, internal/app/ deployment_validation.go:1, internal/app/create.go:53, internal/app/infra_tfvars.go:39, internal/app/root.go:185, and internal/setup/wizard.go:233. Generic config validation no longer rejects partial or missing GitHub auth, a new deployment-specific validator now gates deploy-time flows, init now requires a GitHub auth step with App auth as the default/recommended path, and the user-token path is still available but explicitly framed for personal/dev use. I also updated the setup/deploy docs and refreshed the related tests.

<!-- close -->