### PR TITLE
Add GitHub deployment verification

### DIFF
--- a/internal/app/github_test.go
+++ b/internal/app/github_test.go
@@ -128,13 +128,43 @@ func TestVerifyLocalGitHubAuthUsesUserToken(t *testing.T) {
 func TestVerifyRemoteGitHubAccess(t *testing.T) {
 	exec := &testHostExecutor{
 		runFn: func(ctx context.Context, command string, args ...string) (host.CommandResult, error) {
-			if command != "git" || len(args) != 2 || args[0] != "ls-remote" || args[1] != "https://github.com/owner/repo" {
+			switch {
+			case command != "git":
+				t.Fatalf("unexpected command: %s %v", command, args)
+			case len(args) == 4 && args[0] == "config" && args[1] == "--global" && args[2] == "--get" && args[3] == "credential.helper":
+				return host.CommandResult{Stdout: "!/opt/agenthub/bin/agenthub github credential --runtime-config /opt/agenthub/runtime.yaml"}, nil
+			case len(args) == 4 && args[0] == "config" && args[1] == "--global" && args[2] == "--get" && args[3] == "url.https://github.com/.insteadof":
+				return host.CommandResult{Stdout: "git@github.com:"}, nil
+			case len(args) == 2 && args[0] == "ls-remote" && args[1] == "https://github.com/owner/repo":
+				return host.CommandResult{Stdout: "deadbeef\tHEAD"}, nil
+			default:
 				t.Fatalf("unexpected command: %s %v", command, args)
 			}
-			return host.CommandResult{Stdout: "deadbeef\tHEAD"}, nil
+			return host.CommandResult{}, nil
 		},
 	}
 	if err := verifyRemoteGitHubAccess(context.Background(), exec, "https://github.com/owner/repo"); err != nil {
 		t.Fatalf("verifyRemoteGitHubAccess() error = %v", err)
+	}
+}
+
+func TestVerifyGitHubCredentialHelperConfigured(t *testing.T) {
+	exec := &testHostExecutor{
+		runFn: func(ctx context.Context, command string, args ...string) (host.CommandResult, error) {
+			switch {
+			case command != "git":
+				t.Fatalf("unexpected command: %s %v", command, args)
+			case len(args) == 4 && args[0] == "config" && args[1] == "--global" && args[2] == "--get" && args[3] == "credential.helper":
+				return host.CommandResult{Stdout: "!/opt/agenthub/bin/agenthub github credential --runtime-config /opt/agenthub/runtime.yaml"}, nil
+			case len(args) == 4 && args[0] == "config" && args[1] == "--global" && args[2] == "--get" && args[3] == "url.https://github.com/.insteadof":
+				return host.CommandResult{Stdout: "git@github.com:"}, nil
+			default:
+				t.Fatalf("unexpected command: %s %v", command, args)
+			}
+			return host.CommandResult{}, nil
+		},
+	}
+	if err := verifyGitHubCredentialHelperConfigured(context.Background(), exec); err != nil {
+		t.Fatalf("verifyGitHubCredentialHelperConfigured() error = %v", err)
 	}
 }

--- a/internal/app/github_test.go
+++ b/internal/app/github_test.go
@@ -148,6 +148,29 @@ func TestVerifyRemoteGitHubAccess(t *testing.T) {
 	}
 }
 
+func TestVerifyRemoteGitHubAccessRejectsEmptyLsRemoteOutput(t *testing.T) {
+	exec := &testHostExecutor{
+		runFn: func(ctx context.Context, command string, args ...string) (host.CommandResult, error) {
+			switch {
+			case command != "git":
+				t.Fatalf("unexpected command: %s %v", command, args)
+			case len(args) == 4 && args[0] == "config" && args[1] == "--global" && args[2] == "--get" && args[3] == "credential.helper":
+				return host.CommandResult{Stdout: "!/opt/agenthub/bin/agenthub github credential --runtime-config /opt/agenthub/runtime.yaml"}, nil
+			case len(args) == 4 && args[0] == "config" && args[1] == "--global" && args[2] == "--get" && args[3] == "url.https://github.com/.insteadof":
+				return host.CommandResult{Stdout: "git@github.com:"}, nil
+			case len(args) == 2 && args[0] == "ls-remote" && args[1] == "https://github.com/owner/repo":
+				return host.CommandResult{Stdout: ""}, nil
+			default:
+				t.Fatalf("unexpected command: %s %v", command, args)
+			}
+			return host.CommandResult{}, nil
+		},
+	}
+	if err := verifyRemoteGitHubAccess(context.Background(), exec, "https://github.com/owner/repo"); err == nil {
+		t.Fatal("verifyRemoteGitHubAccess() error = nil, want failure for empty ls-remote output")
+	}
+}
+
 func TestVerifyGitHubCredentialHelperConfigured(t *testing.T) {
 	exec := &testHostExecutor{
 		runFn: func(ctx context.Context, command string, args ...string) (host.CommandResult, error) {

--- a/internal/app/github_test.go
+++ b/internal/app/github_test.go
@@ -1,11 +1,25 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"agenthub/internal/config"
+	"agenthub/internal/host"
 	"agenthub/internal/runtimeinstall"
 )
+
+type testHostExecutor struct {
+	runFn func(ctx context.Context, command string, args ...string) (host.CommandResult, error)
+}
+
+func (e *testHostExecutor) Run(ctx context.Context, command string, args ...string) (host.CommandResult, error) {
+	return e.runFn(ctx, command, args...)
+}
+
+func (e *testHostExecutor) Upload(ctx context.Context, localPath, remotePath string) error {
+	return nil
+}
 
 func TestHasGitHubRuntimeConfigAcceptsUserAuth(t *testing.T) {
 	cfg := &runtimeinstall.RuntimeConfig{
@@ -31,5 +45,96 @@ func TestHasGitHubRuntimeConfigRejectsIncompleteAppAuth(t *testing.T) {
 
 	if hasGitHubRuntimeConfig(cfg) {
 		t.Fatal("hasGitHubRuntimeConfig() = true, want false for incomplete app auth")
+	}
+}
+
+func TestNormalizeGitHubRemoteURL(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/owner/repo.git":   "https://github.com/owner/repo",
+		"git@github.com:owner/repo.git":       "https://github.com/owner/repo",
+		"ssh://git@github.com/owner/repo.git": "https://github.com/owner/repo",
+		"https://github.com/owner/repo":       "https://github.com/owner/repo",
+	}
+	for input, want := range cases {
+		got, err := normalizeGitHubRemoteURL(input)
+		if err != nil {
+			t.Fatalf("normalizeGitHubRemoteURL(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("normalizeGitHubRemoteURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestNormalizeGitHubRemoteURLRejectsNonGitHub(t *testing.T) {
+	for _, input := range []string{
+		"git@bitbucket.org:owner/repo.git",
+		"https://example.com/owner/repo.git",
+		"not-a-remote",
+		"https://github.com/owner",
+	} {
+		if _, err := normalizeGitHubRemoteURL(input); err == nil {
+			t.Fatalf("normalizeGitHubRemoteURL(%q) error = nil, want rejection", input)
+		}
+	}
+}
+
+func TestVerifyLocalGitHubAuthUsesAppInstallationToken(t *testing.T) {
+	original := loadGitHubInstallationToken
+	defer func() { loadGitHubInstallationToken = original }()
+	called := false
+	loadGitHubInstallationToken = func(ctx context.Context, region string, cfg config.GitHubConfig) (string, error) {
+		called = true
+		if region != "us-east-1" {
+			t.Fatalf("region = %q, want us-east-1", region)
+		}
+		return "token", nil
+	}
+	cfg := &config.Config{
+		Region: config.RegionConfig{Name: "us-east-1"},
+		GitHub: config.GitHubConfig{AuthMode: config.GitHubAuthModeApp},
+	}
+	if err := verifyLocalGitHubAuth(context.Background(), cfg); err != nil {
+		t.Fatalf("verifyLocalGitHubAuth() error = %v", err)
+	}
+	if !called {
+		t.Fatal("verifyLocalGitHubAuth() did not mint an installation token")
+	}
+}
+
+func TestVerifyLocalGitHubAuthUsesUserToken(t *testing.T) {
+	original := loadGitHubUserToken
+	defer func() { loadGitHubUserToken = original }()
+	called := false
+	loadGitHubUserToken = func(ctx context.Context, region, secretID string) (string, error) {
+		called = true
+		if secretID != "arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-token" {
+			t.Fatalf("secretID = %q, want configured token secret", secretID)
+		}
+		return "token", nil
+	}
+	cfg := &config.Config{
+		Region: config.RegionConfig{Name: "us-east-1"},
+		GitHub: config.GitHubConfig{AuthMode: config.GitHubAuthModeUser, TokenSecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-token"},
+	}
+	if err := verifyLocalGitHubAuth(context.Background(), cfg); err != nil {
+		t.Fatalf("verifyLocalGitHubAuth() error = %v", err)
+	}
+	if !called {
+		t.Fatal("verifyLocalGitHubAuth() did not load the user token")
+	}
+}
+
+func TestVerifyRemoteGitHubAccess(t *testing.T) {
+	exec := &testHostExecutor{
+		runFn: func(ctx context.Context, command string, args ...string) (host.CommandResult, error) {
+			if command != "git" || len(args) != 2 || args[0] != "ls-remote" || args[1] != "https://github.com/owner/repo" {
+				t.Fatalf("unexpected command: %s %v", command, args)
+			}
+			return host.CommandResult{Stdout: "deadbeef\tHEAD"}, nil
+		},
+	}
+	if err := verifyRemoteGitHubAccess(context.Background(), exec, "https://github.com/owner/repo"); err != nil {
+		t.Fatalf("verifyRemoteGitHubAccess() error = %v", err)
 	}
 }

--- a/internal/app/github_test_main_test.go
+++ b/internal/app/github_test_main_test.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"agenthub/internal/config"
+	"agenthub/internal/host"
+)
+
+func TestMain(m *testing.M) {
+	originalOrigin := gitRemoteOriginURLFunc
+	originalAppToken := loadGitHubInstallationToken
+	originalUserToken := loadGitHubUserToken
+	originalRemoteVerify := verifyRemoteGitHubAccessFunc
+	gitRemoteOriginURLFunc = func(ctx context.Context) (string, error) {
+		return "git@github.com:owner/repo.git", nil
+	}
+	loadGitHubInstallationToken = func(ctx context.Context, region string, cfg config.GitHubConfig) (string, error) {
+		return "test-app-token", nil
+	}
+	loadGitHubUserToken = func(ctx context.Context, region, secretID string) (string, error) {
+		return "test-user-token", nil
+	}
+	verifyRemoteGitHubAccessFunc = func(ctx context.Context, exec host.Executor, repoURL string) error {
+		return nil
+	}
+
+	code := m.Run()
+
+	gitRemoteOriginURLFunc = originalOrigin
+	loadGitHubInstallationToken = originalAppToken
+	loadGitHubUserToken = originalUserToken
+	verifyRemoteGitHubAccessFunc = originalRemoteVerify
+	os.Exit(code)
+}

--- a/internal/app/github_verify.go
+++ b/internal/app/github_verify.go
@@ -1,0 +1,141 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"agenthub/internal/config"
+	"agenthub/internal/githubauth"
+	"agenthub/internal/host"
+)
+
+var gitRemoteOriginURLFunc = func(ctx context.Context) (string, error) {
+	remoteURL, err := gitOutput(ctx, "git", "remote", "get-url", "origin")
+	if err != nil {
+		return "", err
+	}
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return "", errors.New("git remote origin is required to verify GitHub deployment dependencies")
+	}
+	return remoteURL, nil
+}
+
+var loadGitHubInstallationToken = githubauth.InstallationToken
+var loadGitHubUserToken = githubauth.LoadToken
+var verifyRemoteGitHubAccessFunc = verifyRemoteGitHubAccess
+
+type githubVerificationTarget struct {
+	RemoteURL string
+	HTTPSURL  string
+}
+
+func resolveGitHubVerificationTarget(ctx context.Context) (githubVerificationTarget, error) {
+	remoteURL, err := gitRemoteOriginURLFunc(ctx)
+	if err != nil {
+		return githubVerificationTarget{}, err
+	}
+	normalized, err := normalizeGitHubRemoteURL(remoteURL)
+	if err != nil {
+		return githubVerificationTarget{}, err
+	}
+	return githubVerificationTarget{
+		RemoteURL: remoteURL,
+		HTTPSURL:  normalized,
+	}, nil
+}
+
+func normalizeGitHubRemoteURL(remoteURL string) (string, error) {
+	trimmed := strings.TrimSpace(remoteURL)
+	if trimmed == "" {
+		return "", errors.New("git remote origin is required to verify GitHub deployment dependencies")
+	}
+
+	if strings.HasPrefix(trimmed, "git@github.com:") {
+		return normalizeGitHubPath("https://github.com/", strings.TrimPrefix(trimmed, "git@github.com:"))
+	}
+	if strings.HasPrefix(trimmed, "ssh://git@github.com/") {
+		return normalizeGitHubPath("https://github.com/", strings.TrimPrefix(trimmed, "ssh://git@github.com/"))
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("unsupported GitHub remote %q", remoteURL)
+	}
+	if !strings.EqualFold(parsed.Host, "github.com") {
+		return "", fmt.Errorf("GitHub deployment verification requires a github.com remote, got %q", remoteURL)
+	}
+	return normalizeGitHubPath("https://github.com/", strings.TrimPrefix(parsed.Path, "/"))
+}
+
+func normalizeGitHubPath(prefix, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	path = strings.TrimSuffix(path, ".git")
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return "", errors.New("git remote origin must include an owner/repo path")
+	}
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", fmt.Errorf("git remote origin must resolve to owner/repo, got %q", path)
+	}
+	return prefix + parts[0] + "/" + parts[1], nil
+}
+
+func validateCreateGitHubDeployment(cfg *config.Config, target githubVerificationTarget) error {
+	if cfg == nil {
+		return errors.New("config is required")
+	}
+	if strings.TrimSpace(target.HTTPSURL) == "" {
+		return errors.New("GitHub deployment verification requires a GitHub repository target")
+	}
+	if mode := config.GitHubAuthModeFor(cfg.GitHub); mode == "" {
+		return errors.New("GitHub connectivity is required for deployment; configure github.auth_mode=app (recommended) or github.auth_mode=user")
+	}
+	return nil
+}
+
+func verifyLocalGitHubAuth(ctx context.Context, cfg *config.Config) error {
+	if cfg == nil {
+		return errors.New("config is required")
+	}
+	switch config.GitHubAuthModeFor(cfg.GitHub) {
+	case config.GitHubAuthModeApp:
+		token, err := loadGitHubInstallationToken(ctx, strings.TrimSpace(cfg.Region.Name), cfg.GitHub)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(token) == "" {
+			return errors.New("github installation token response did not contain a token")
+		}
+	case config.GitHubAuthModeUser:
+		token, err := loadGitHubUserToken(ctx, strings.TrimSpace(cfg.Region.Name), cfg.GitHub.TokenSecretARN)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(token) == "" {
+			return errors.New("github token secret did not contain a token")
+		}
+	default:
+		return errors.New("GitHub connectivity is required for deployment; configure github.auth_mode=app (recommended) or github.auth_mode=user")
+	}
+	return nil
+}
+
+func verifyRemoteGitHubAccess(ctx context.Context, exec host.Executor, repoURL string) error {
+	if exec == nil {
+		return errors.New("remote verification requires a host executor")
+	}
+	repoURL = strings.TrimSpace(repoURL)
+	if repoURL == "" {
+		return errors.New("GitHub deployment verification requires a GitHub repository target")
+	}
+	_, err := exec.Run(ctx, "git", "ls-remote", repoURL)
+	if err != nil {
+		return fmt.Errorf("verify GitHub access with git ls-remote %q: %w", repoURL, err)
+	}
+	return nil
+}

--- a/internal/app/github_verify.go
+++ b/internal/app/github_verify.go
@@ -134,11 +134,27 @@ func verifyRemoteGitHubAccess(ctx context.Context, exec host.Executor, repoURL s
 	if err := verifyGitHubCredentialHelperFunc(ctx, exec); err != nil {
 		return err
 	}
-	_, err := exec.Run(ctx, "git", "ls-remote", repoURL)
+	result, err := exec.Run(ctx, "git", "ls-remote", repoURL)
 	if err != nil {
 		return fmt.Errorf("verify GitHub access with git ls-remote %q: %w", repoURL, err)
 	}
+	if !hasGitRemoteRefs(result.Stdout) {
+		return fmt.Errorf("verify GitHub access with git ls-remote %q: expected at least one ref in stdout", repoURL)
+	}
 	return nil
+}
+
+func hasGitRemoteRefs(stdout string) bool {
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "\t") {
+			return true
+		}
+	}
+	return false
 }
 
 func verifyGitHubCredentialHelperConfigured(ctx context.Context, exec host.Executor) error {

--- a/internal/app/github_verify.go
+++ b/internal/app/github_verify.go
@@ -85,12 +85,9 @@ func normalizeGitHubPath(prefix, path string) (string, error) {
 	return prefix + parts[0] + "/" + parts[1], nil
 }
 
-func validateCreateGitHubDeployment(cfg *config.Config, target githubVerificationTarget) error {
+func validateCreateGitHubDeployment(cfg *config.Config) error {
 	if cfg == nil {
 		return errors.New("config is required")
-	}
-	if strings.TrimSpace(target.HTTPSURL) == "" {
-		return errors.New("GitHub deployment verification requires a GitHub repository target")
 	}
 	if mode := config.GitHubAuthModeFor(cfg.GitHub); mode == "" {
 		return errors.New("GitHub connectivity is required for deployment; configure github.auth_mode=app (recommended) or github.auth_mode=user")

--- a/internal/app/github_verify.go
+++ b/internal/app/github_verify.go
@@ -27,6 +27,7 @@ var gitRemoteOriginURLFunc = func(ctx context.Context) (string, error) {
 var loadGitHubInstallationToken = githubauth.InstallationToken
 var loadGitHubUserToken = githubauth.LoadToken
 var verifyRemoteGitHubAccessFunc = verifyRemoteGitHubAccess
+var verifyGitHubCredentialHelperFunc = verifyGitHubCredentialHelperConfigured
 
 type githubVerificationTarget struct {
 	RemoteURL string
@@ -130,9 +131,32 @@ func verifyRemoteGitHubAccess(ctx context.Context, exec host.Executor, repoURL s
 	if repoURL == "" {
 		return errors.New("GitHub deployment verification requires a GitHub repository target")
 	}
+	if err := verifyGitHubCredentialHelperFunc(ctx, exec); err != nil {
+		return err
+	}
 	_, err := exec.Run(ctx, "git", "ls-remote", repoURL)
 	if err != nil {
 		return fmt.Errorf("verify GitHub access with git ls-remote %q: %w", repoURL, err)
+	}
+	return nil
+}
+
+func verifyGitHubCredentialHelperConfigured(ctx context.Context, exec host.Executor) error {
+	if exec == nil {
+		return errors.New("remote verification requires a host executor")
+	}
+	checks := [][]string{
+		{"git", "config", "--global", "--get", "credential.helper"},
+		{"git", "config", "--global", "--get", "url.https://github.com/.insteadof"},
+	}
+	for _, args := range checks {
+		result, err := exec.Run(ctx, args[0], args[1:]...)
+		if err != nil {
+			return fmt.Errorf("verify git credential helper setup with %q: %w", strings.Join(args, " "), err)
+		}
+		if strings.TrimSpace(result.Stdout) == "" {
+			return fmt.Errorf("verify git credential helper setup with %q: expected a configured value", strings.Join(args, " "))
+		}
 	}
 	return nil
 }

--- a/internal/app/workflows.go
+++ b/internal/app/workflows.go
@@ -500,6 +500,19 @@ func runCreateWorkflow(ctx context.Context, profile string, cfg *config.Config, 
 		progress = newProgressRenderer(io.Discard)
 	}
 
+	ghTarget, err := resolveGitHubVerificationTarget(ctx)
+	if err != nil {
+		return nil, runtimeinstall.Result{}, verify.Report{}, err
+	}
+	if err := validateCreateGitHubDeployment(cfg, ghTarget); err != nil {
+		return nil, runtimeinstall.Result{}, verify.Report{}, err
+	}
+	if err := runCreateStage(progress, ctx, "GitHub", "verifying local auth", func(runCtx context.Context) error {
+		return verifyLocalGitHubAuth(runCtx, cfg)
+	}); err != nil {
+		return nil, runtimeinstall.Result{}, verify.Report{}, err
+	}
+
 	var instance *provider.Instance
 	if instance, err = runInfraCreate(ctx, profile, cfg, opts, progress); err != nil {
 		return instance, runtimeinstall.Result{}, verify.Report{}, err
@@ -548,6 +561,12 @@ func runCreateWorkflow(ctx context.Context, profile string, cfg *config.Config, 
 		resolvedTarget = target
 	}
 
+	if err = runCreateStage(progress, ctx, "GitHub", "verifying host GitHub access", func(runCtx context.Context) error {
+		return runRemoteGitHubVerification(runCtx, profile, cfg, opts, resolvedTarget, ghTarget.HTTPSURL)
+	}); err != nil {
+		return instance, installResult, verify.Report{}, err
+	}
+
 	var verifyReport verify.Report
 	if err = runCreateStage(progress, ctx, "Runtime", "verifying runtime", func(runCtx context.Context) error {
 		var err error
@@ -582,6 +601,30 @@ func cleanupCreatedInstance(ctx context.Context, profile string, cfg *config.Con
 	provider := newAWSProvider(profile, cfg.Compute.Class)
 	if err := provider.DeleteInstance(cleanupCtx, region, instance.ID); err != nil {
 		return fmt.Errorf("cleanup created instance %s: %w", instance.ID, err)
+	}
+	return nil
+}
+
+func runRemoteGitHubVerification(ctx context.Context, profile string, cfg *config.Config, opts createOptions, target, repoURL string) error {
+	if strings.TrimSpace(target) == "" {
+		return errors.New("target is required")
+	}
+	user, keyPath, err := resolveInstallSSH(cfg, opts.SSHUser, opts.SSHKey)
+	if err != nil {
+		return err
+	}
+	exec := newSSHExecutor(host.SSHConfig{
+		Host:           target,
+		Port:           opts.SSHPort,
+		User:           user,
+		IdentityFile:   keyPath,
+		ConnectTimeout: 15 * time.Second,
+	})
+	if err := waitForSSHReady(ctx, exec, target); err != nil {
+		return err
+	}
+	if err := verifyRemoteGitHubAccessFunc(ctx, exec, repoURL); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/app/workflows.go
+++ b/internal/app/workflows.go
@@ -500,11 +500,7 @@ func runCreateWorkflow(ctx context.Context, profile string, cfg *config.Config, 
 		progress = newProgressRenderer(io.Discard)
 	}
 
-	ghTarget, err := resolveGitHubVerificationTarget(ctx)
-	if err != nil {
-		return nil, runtimeinstall.Result{}, verify.Report{}, err
-	}
-	if err := validateCreateGitHubDeployment(cfg, ghTarget); err != nil {
+	if err := validateCreateGitHubDeployment(cfg); err != nil {
 		return nil, runtimeinstall.Result{}, verify.Report{}, err
 	}
 	if err := runCreateStage(progress, ctx, "GitHub", "verifying local auth", func(runCtx context.Context) error {
@@ -562,7 +558,7 @@ func runCreateWorkflow(ctx context.Context, profile string, cfg *config.Config, 
 	}
 
 	if err = runCreateStage(progress, ctx, "GitHub", "verifying host GitHub access", func(runCtx context.Context) error {
-		return runRemoteGitHubVerification(runCtx, profile, cfg, opts, resolvedTarget, ghTarget.HTTPSURL)
+		return runRemoteGitHubVerification(runCtx, profile, cfg, opts, resolvedTarget)
 	}); err != nil {
 		return instance, installResult, verify.Report{}, err
 	}
@@ -605,9 +601,13 @@ func cleanupCreatedInstance(ctx context.Context, profile string, cfg *config.Con
 	return nil
 }
 
-func runRemoteGitHubVerification(ctx context.Context, profile string, cfg *config.Config, opts createOptions, target, repoURL string) error {
+func runRemoteGitHubVerification(ctx context.Context, profile string, cfg *config.Config, opts createOptions, target string) error {
 	if strings.TrimSpace(target) == "" {
 		return errors.New("target is required")
+	}
+	ghTarget, err := resolveGitHubVerificationTarget(ctx)
+	if err != nil {
+		return err
 	}
 	user, keyPath, err := resolveInstallSSH(cfg, opts.SSHUser, opts.SSHKey)
 	if err != nil {
@@ -623,7 +623,7 @@ func runRemoteGitHubVerification(ctx context.Context, profile string, cfg *confi
 	if err := waitForSSHReady(ctx, exec, target); err != nil {
 		return err
 	}
-	if err := verifyRemoteGitHubAccessFunc(ctx, exec, repoURL); err != nil {
+	if err := verifyRemoteGitHubAccessFunc(ctx, exec, ghTarget.HTTPSURL); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #112 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
  - Added GitHub remote normalization and verification helpers in internal/app/
    github_verify.go.
  - Wired agenthub create to:
      - verify local GitHub auth before provisioning
      - verify remote host GitHub access after runtime install
      - keep runtime verification separate
  - Added test coverage for:
      - GitHub remote normalization
      - local auth preflight
      - remote git ls-remote verification
  - Added a test-time seam so the existing create workflow tests do not hit real AWS/
    GitHub during verification.

  Validation:

  - go test ./... passes
  - working tree is clean

  One note:

  - I made the workflow behavior change in a single commit rather than multiple smaller
    commits because the new verification path and the test harness adjustments were
    tightly coupled. If you want, I can still split the history into finer commits on a
    new branch, but that would require rewriting the current commit history.

<!-- close -->