### PR TITLE
Github secret lookup

### DIFF
--- a/internal/app/github_test.go
+++ b/internal/app/github_test.go
@@ -83,8 +83,11 @@ func TestVerifyLocalGitHubAuthUsesAppInstallationToken(t *testing.T) {
 	original := loadGitHubInstallationToken
 	defer func() { loadGitHubInstallationToken = original }()
 	called := false
-	loadGitHubInstallationToken = func(ctx context.Context, region string, cfg config.GitHubConfig) (string, error) {
+	loadGitHubInstallationToken = func(ctx context.Context, profile, region string, cfg config.GitHubConfig) (string, error) {
 		called = true
+		if profile != "sso-dev" {
+			t.Fatalf("profile = %q, want sso-dev", profile)
+		}
 		if region != "us-east-1" {
 			t.Fatalf("region = %q, want us-east-1", region)
 		}
@@ -94,7 +97,7 @@ func TestVerifyLocalGitHubAuthUsesAppInstallationToken(t *testing.T) {
 		Region: config.RegionConfig{Name: "us-east-1"},
 		GitHub: config.GitHubConfig{AuthMode: config.GitHubAuthModeApp},
 	}
-	if err := verifyLocalGitHubAuth(context.Background(), cfg); err != nil {
+	if err := verifyLocalGitHubAuth(context.Background(), "sso-dev", cfg); err != nil {
 		t.Fatalf("verifyLocalGitHubAuth() error = %v", err)
 	}
 	if !called {
@@ -106,8 +109,11 @@ func TestVerifyLocalGitHubAuthUsesUserToken(t *testing.T) {
 	original := loadGitHubUserToken
 	defer func() { loadGitHubUserToken = original }()
 	called := false
-	loadGitHubUserToken = func(ctx context.Context, region, secretID string) (string, error) {
+	loadGitHubUserToken = func(ctx context.Context, profile, region, secretID string) (string, error) {
 		called = true
+		if profile != "sso-dev" {
+			t.Fatalf("profile = %q, want sso-dev", profile)
+		}
 		if secretID != "arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-token" {
 			t.Fatalf("secretID = %q, want configured token secret", secretID)
 		}
@@ -117,7 +123,7 @@ func TestVerifyLocalGitHubAuthUsesUserToken(t *testing.T) {
 		Region: config.RegionConfig{Name: "us-east-1"},
 		GitHub: config.GitHubConfig{AuthMode: config.GitHubAuthModeUser, TokenSecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-token"},
 	}
-	if err := verifyLocalGitHubAuth(context.Background(), cfg); err != nil {
+	if err := verifyLocalGitHubAuth(context.Background(), "sso-dev", cfg); err != nil {
 		t.Fatalf("verifyLocalGitHubAuth() error = %v", err)
 	}
 	if !called {

--- a/internal/app/github_test_main_test.go
+++ b/internal/app/github_test_main_test.go
@@ -7,12 +7,14 @@ import (
 
 	"agenthub/internal/config"
 	"agenthub/internal/host"
+	"agenthub/internal/setup"
 )
 
 func TestMain(m *testing.M) {
 	originalOrigin := gitRemoteOriginURLFunc
 	originalAppToken := loadGitHubInstallationToken
 	originalUserToken := loadGitHubUserToken
+	originalGitIdentity := setup.LookupGitIdentityFunc
 	originalRemoteVerify := verifyRemoteGitHubAccessFunc
 	gitRemoteOriginURLFunc = func(ctx context.Context) (string, error) {
 		return "git@github.com:owner/repo.git", nil
@@ -23,6 +25,9 @@ func TestMain(m *testing.M) {
 	loadGitHubUserToken = func(ctx context.Context, profile, region, secretID string) (string, error) {
 		return "test-user-token", nil
 	}
+	setup.LookupGitIdentityFunc = func(ctx context.Context) (setup.GitIdentity, error) {
+		return setup.GitIdentity{Name: "Test User", Email: "test@example.com"}, nil
+	}
 	verifyRemoteGitHubAccessFunc = func(ctx context.Context, exec host.Executor, repoURL string) error {
 		return nil
 	}
@@ -32,6 +37,7 @@ func TestMain(m *testing.M) {
 	gitRemoteOriginURLFunc = originalOrigin
 	loadGitHubInstallationToken = originalAppToken
 	loadGitHubUserToken = originalUserToken
+	setup.LookupGitIdentityFunc = originalGitIdentity
 	verifyRemoteGitHubAccessFunc = originalRemoteVerify
 	os.Exit(code)
 }

--- a/internal/app/github_test_main_test.go
+++ b/internal/app/github_test_main_test.go
@@ -17,10 +17,10 @@ func TestMain(m *testing.M) {
 	gitRemoteOriginURLFunc = func(ctx context.Context) (string, error) {
 		return "git@github.com:owner/repo.git", nil
 	}
-	loadGitHubInstallationToken = func(ctx context.Context, region string, cfg config.GitHubConfig) (string, error) {
+	loadGitHubInstallationToken = func(ctx context.Context, profile, region string, cfg config.GitHubConfig) (string, error) {
 		return "test-app-token", nil
 	}
-	loadGitHubUserToken = func(ctx context.Context, region, secretID string) (string, error) {
+	loadGitHubUserToken = func(ctx context.Context, profile, region, secretID string) (string, error) {
 		return "test-user-token", nil
 	}
 	verifyRemoteGitHubAccessFunc = func(ctx context.Context, exec host.Executor, repoURL string) error {

--- a/internal/app/github_verify.go
+++ b/internal/app/github_verify.go
@@ -96,13 +96,13 @@ func validateCreateGitHubDeployment(cfg *config.Config) error {
 	return nil
 }
 
-func verifyLocalGitHubAuth(ctx context.Context, cfg *config.Config) error {
+func verifyLocalGitHubAuth(ctx context.Context, profile string, cfg *config.Config) error {
 	if cfg == nil {
 		return errors.New("config is required")
 	}
 	switch config.GitHubAuthModeFor(cfg.GitHub) {
 	case config.GitHubAuthModeApp:
-		token, err := loadGitHubInstallationToken(ctx, strings.TrimSpace(cfg.Region.Name), cfg.GitHub)
+		token, err := loadGitHubInstallationToken(ctx, strings.TrimSpace(profile), strings.TrimSpace(cfg.Region.Name), cfg.GitHub)
 		if err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func verifyLocalGitHubAuth(ctx context.Context, cfg *config.Config) error {
 			return errors.New("github installation token response did not contain a token")
 		}
 	case config.GitHubAuthModeUser:
-		token, err := loadGitHubUserToken(ctx, strings.TrimSpace(cfg.Region.Name), cfg.GitHub.TokenSecretARN)
+		token, err := loadGitHubUserToken(ctx, strings.TrimSpace(profile), strings.TrimSpace(cfg.Region.Name), cfg.GitHub.TokenSecretARN)
 		if err != nil {
 			return err
 		}

--- a/internal/app/infra_destroy.go
+++ b/internal/app/infra_destroy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -141,7 +142,7 @@ func runInfraDestroy(ctx context.Context, profile string, cfg *config.Config, op
 	if err != nil {
 		return err
 	}
-	if err := backend.Destroy(ctx, workdir, varsPath); err != nil {
+	if err := backend.Destroy(ctx, workdir, filepath.Base(varsPath)); err != nil {
 		return err
 	}
 	if !isEphemeralTerraformWorkdir(workdir) {

--- a/internal/app/infra_destroy_test.go
+++ b/internal/app/infra_destroy_test.go
@@ -44,8 +44,8 @@ func TestInfraDestroyCommandDestroysInfrastructureAndClearsDeployState(t *testin
 			onInit: func(workdir string) { initCalled = true },
 			onDestroy: func(workdir, varsFile string) {
 				destroyCalled = true
-				if !strings.HasPrefix(varsFile, workdir) {
-					t.Fatalf("vars file = %q, want path under %q", varsFile, workdir)
+				if varsFile != "agenthub.auto.tfvars.json" {
+					t.Fatalf("vars file = %q, want terraform-readable basename", varsFile)
 				}
 			},
 		}, nil

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -96,6 +96,9 @@ func TestInitWritesConfigFile(t *testing.T) {
 		`app_id: "123456"`,
 		`installation_id: "789012"`,
 		"private_key_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
+		"git:",
+		"name: Test User",
+		"email: test@example.com",
 	} {
 		if !strings.Contains(body, fragment) {
 			t.Fatalf("config file %q missing %q", body, fragment)

--- a/internal/app/workflows.go
+++ b/internal/app/workflows.go
@@ -504,7 +504,7 @@ func runCreateWorkflow(ctx context.Context, profile string, cfg *config.Config, 
 		return nil, runtimeinstall.Result{}, verify.Report{}, err
 	}
 	if err := runCreateStage(progress, ctx, "GitHub", "verifying local auth", func(runCtx context.Context) error {
-		return verifyLocalGitHubAuth(runCtx, cfg)
+		return verifyLocalGitHubAuth(runCtx, profile, cfg)
 	}); err != nil {
 		return nil, runtimeinstall.Result{}, verify.Report{}, err
 	}

--- a/internal/app/workflows.go
+++ b/internal/app/workflows.go
@@ -258,7 +258,7 @@ func runInfraCreate(ctx context.Context, profile string, cfg *config.Config, opt
 				}
 			}
 		}
-		if err := backend.Plan(runCtx, workdir, varsPath); err != nil {
+		if err := backend.Plan(runCtx, workdir, filepath.Base(varsPath)); err != nil {
 			return err
 		}
 		return nil
@@ -275,7 +275,7 @@ func runInfraCreate(ctx context.Context, profile string, cfg *config.Config, opt
 	}
 
 	if err := runCreateStage(progress, ctx, "Infrastructure", "apply terraform", func(runCtx context.Context) error {
-		if err := backend.Apply(runCtx, workdir, varsPath); err != nil {
+		if err := backend.Apply(runCtx, workdir, filepath.Base(varsPath)); err != nil {
 			return err
 		}
 		var outErr error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Image    ImageConfig    `yaml:"image"`
 	Runtime  RuntimeConfig  `yaml:"runtime"`
 	GitHub   GitHubConfig   `yaml:"github,omitempty"`
+	Git      GitConfig      `yaml:"git,omitempty"`
 	Slack    SlackConfig    `yaml:"slack,omitempty"`
 	SSH      SSHConfig      `yaml:"ssh,omitempty"`
 	Infra    InfraConfig    `yaml:"infra,omitempty"`
@@ -85,6 +86,11 @@ type GitHubConfig struct {
 	PrivateKeySecretARN string `yaml:"private_key_secret_arn,omitempty"`
 	SSHKeySecretARN     string `yaml:"ssh_key_secret_arn,omitempty"`
 	TokenSecretARN      string `yaml:"token_secret_arn,omitempty"`
+}
+
+type GitConfig struct {
+	Name  string `yaml:"name,omitempty"`
+	Email string `yaml:"email,omitempty"`
 }
 
 type SlackConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,38 @@ sandbox:
 	}
 }
 
+func TestLoadPreservesGitIdentity(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agenthub.yaml")
+	writeFile(t, path, `
+platform:
+  name: aws
+region:
+  name: us-east-1
+instance:
+  type: t3.medium
+  disk_size_gb: 20
+image:
+  name: ubuntu-24.04
+runtime:
+  endpoint: http://localhost:11434
+  provider: codex
+git:
+  name: Test User
+  email: test@example.com
+sandbox:
+  enabled: true
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Git.Name != "Test User" || cfg.Git.Email != "test@example.com" {
+		t.Fatalf("Git identity = %+v, want Test User/test@example.com", cfg.Git)
+	}
+}
+
 func TestValidateAllowsCodexWithoutSecretID(t *testing.T) {
 	cfg := &Config{
 		Platform: PlatformConfig{Name: PlatformAWS},

--- a/internal/githubauth/githubauth.go
+++ b/internal/githubauth/githubauth.go
@@ -31,12 +31,12 @@ type Credential struct {
 	Password string
 }
 
-func InstallationToken(ctx context.Context, region string, cfg config.GitHubConfig) (string, error) {
+func InstallationToken(ctx context.Context, profile, region string, cfg config.GitHubConfig) (string, error) {
 	if strings.TrimSpace(cfg.AppID) == "" || strings.TrimSpace(cfg.InstallationID) == "" || strings.TrimSpace(cfg.PrivateKeySecretARN) == "" {
 		return "", errors.New("github auth requires app id, installation id, and private key secret arn")
 	}
 
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(strings.TrimSpace(region)))
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(strings.TrimSpace(region)), awsconfig.WithSharedConfigProfile(strings.TrimSpace(profile)))
 	if err != nil {
 		return "", fmt.Errorf("load aws config for github auth: %w", err)
 	}
@@ -102,13 +102,13 @@ func InstallationToken(ctx context.Context, region string, cfg config.GitHubConf
 func CredentialForGit(ctx context.Context, region string, cfg config.GitHubConfig) (Credential, error) {
 	switch config.GitHubAuthModeFor(cfg) {
 	case config.GitHubAuthModeUser:
-		token, err := LoadToken(ctx, region, cfg.TokenSecretARN)
+		token, err := LoadToken(ctx, "", region, cfg.TokenSecretARN)
 		if err != nil {
 			return Credential{}, err
 		}
 		return Credential{Username: "x-access-token", Password: token}, nil
 	case config.GitHubAuthModeApp, "":
-		token, err := InstallationToken(ctx, region, cfg)
+		token, err := InstallationToken(ctx, "", region, cfg)
 		if err != nil {
 			return Credential{}, err
 		}
@@ -159,13 +159,13 @@ func StoreToken(ctx context.Context, profile, region, secretName, token string) 
 	return secretName, nil
 }
 
-func LoadToken(ctx context.Context, region, secretID string) (string, error) {
+func LoadToken(ctx context.Context, profile, region, secretID string) (string, error) {
 	secretID = strings.TrimSpace(secretID)
 	if secretID == "" {
 		return "", errors.New("github token secret id is required")
 	}
 
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(strings.TrimSpace(region)))
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(strings.TrimSpace(region)), awsconfig.WithSharedConfigProfile(strings.TrimSpace(profile)))
 	if err != nil {
 		return "", fmt.Errorf("load aws config for github token secret: %w", err)
 	}

--- a/internal/infra/terraform/backend.go
+++ b/internal/infra/terraform/backend.go
@@ -253,7 +253,13 @@ func cleanWorkspaceForModuleCopy(workdir string) error {
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if name == ".terraform" || name == "terraform.tfstate" || strings.HasPrefix(name, "terraform.tfstate.") {
+		if name == ".terraform" ||
+			name == "terraform.tfstate" ||
+			strings.HasPrefix(name, "terraform.tfstate.") ||
+			strings.HasSuffix(name, ".tfvars") ||
+			strings.HasSuffix(name, ".tfvars.json") ||
+			strings.HasSuffix(name, ".auto.tfvars") ||
+			strings.HasSuffix(name, ".auto.tfvars.json") {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(workdir, name)); err != nil {

--- a/internal/infra/terraform/backend_test.go
+++ b/internal/infra/terraform/backend_test.go
@@ -180,6 +180,10 @@ func TestTerraformBackendPrepareWorkspaceRefreshesModuleAndPreservesState(t *tes
 	if err := os.WriteFile(filepath.Join(workdir, "stale.tf"), []byte("stale\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(stale.tf) error = %v", err)
 	}
+	varsPath := filepath.Join(workdir, "agenthub.auto.tfvars.json")
+	if err := os.WriteFile(varsPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(agenthub.auto.tfvars.json) error = %v", err)
+	}
 
 	binDir := filepath.Join(dir, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -207,12 +211,18 @@ func TestTerraformBackendPrepareWorkspaceRefreshesModuleAndPreservesState(t *tes
 	if _, err := os.Stat(filepath.Join(workdir, "stale.tf")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Stat(stale.tf) error = %v, want not exist", err)
 	}
+	if _, err := os.Stat(varsPath); err != nil {
+		t.Fatalf("Stat(agenthub.auto.tfvars.json) error = %v", err)
+	}
 
 	if err := os.WriteFile(modulePath, []byte("terraform {\n  required_version = \">= 1.6.0\"\n}\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(main.tf updated) error = %v", err)
 	}
 	if err := backend.Init(context.Background(), workdir); err != nil {
 		t.Fatalf("Init() second call error = %v", err)
+	}
+	if _, err := os.Stat(varsPath); err != nil {
+		t.Fatalf("Stat(agenthub.auto.tfvars.json) after second init error = %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(workdir, "main.tf"))
 	if err != nil {

--- a/internal/runtimeinstall/install.go
+++ b/internal/runtimeinstall/install.go
@@ -195,6 +195,17 @@ func (i Installer) Install(ctx context.Context, req Request) (Result, error) {
 			}, err
 		}
 	}
+	if err := i.configureGitIdentity(ctx, req); err != nil {
+		return Result{
+			WorkingDir:     workingDir,
+			ConfigPath:     remoteConfigPath,
+			ScriptPath:     remoteScriptPath,
+			BinaryPath:     serviceResult.BinaryPath,
+			ServicePath:    serviceResult.ServicePath,
+			Prerequisites:  report,
+			CommandResults: []host.CommandResult{cmdResult},
+		}, err
+	}
 
 	return Result{
 		WorkingDir:     workingDir,
@@ -329,6 +340,31 @@ func (i Installer) configureGitHubAuth(ctx context.Context, req Request, working
 	default:
 		return fmt.Errorf("unsupported github auth mode %q", req.Config.GitHub.AuthMode)
 	}
+}
+
+func (i Installer) configureGitIdentity(ctx context.Context, req Request) error {
+	if i.Host == nil || req.Config == nil {
+		return nil
+	}
+	name := strings.TrimSpace(req.Config.Git.Name)
+	email := strings.TrimSpace(req.Config.Git.Email)
+	if name == "" && email == "" {
+		return nil
+	}
+	if err := ensureGitAvailable(ctx, i.Host); err != nil {
+		return err
+	}
+	if name != "" {
+		if _, err := i.Host.Run(ctx, "git", "config", "--global", "user.name", name); err != nil {
+			return fmt.Errorf("configure git user.name: %w", err)
+		}
+	}
+	if email != "" {
+		if _, err := i.Host.Run(ctx, "git", "config", "--global", "user.email", email); err != nil {
+			return fmt.Errorf("configure git user.email: %w", err)
+		}
+	}
+	return nil
 }
 
 func buildRuntimeBinary(ctx context.Context) (string, error) {

--- a/internal/runtimeinstall/install_test.go
+++ b/internal/runtimeinstall/install_test.go
@@ -178,9 +178,11 @@ func TestInstallerConfiguresGitHubCredentialHelper(t *testing.T) {
 			"git config --global credential.helper !/opt/agenthub/bin/agenthub github credential --runtime-config /opt/agenthub/runtime.yaml": {},
 			"git config --global url.https://github.com/.insteadOf git@github.com:":                                                           {},
 			"git config --global url.https://github.com/.insteadOf ssh://git@github.com/":                                                     {},
+			"git config --global user.name Test User":                                                                                         {},
+			"git config --global user.email test@example.com":                                                                                 {},
 			"sudo mv /opt/agenthub/agenthub.service /etc/systemd/system/agenthub.service":                                                     {},
-			"sudo systemctl daemon-reload":                 {},
-			"sudo systemctl enable --now agenthub.service": {},
+			"sudo systemctl daemon-reload":                                                                                                    {},
+			"sudo systemctl enable --now agenthub.service":                                                                                    {},
 		},
 	}
 
@@ -197,6 +199,7 @@ func TestInstallerConfiguresGitHubCredentialHelper(t *testing.T) {
 				InstallationID:      "789012",
 				PrivateKeySecretARN: "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:agenthub/github-app-private-key",
 			},
+			Git:     config.GitConfig{Name: "Test User", Email: "test@example.com"},
 			Sandbox: config.SandboxConfig{Enabled: true, NetworkMode: "private", UseNemoClaw: true},
 		},
 		WorkingDir: "/opt/agenthub",
@@ -235,9 +238,11 @@ func TestInstallerConfiguresGitHubCredentialHelperForUserAuth(t *testing.T) {
 			"git config --global credential.helper !/opt/agenthub/bin/agenthub github credential --runtime-config /opt/agenthub/runtime.yaml": {},
 			"git config --global url.https://github.com/.insteadOf git@github.com:":                                                           {},
 			"git config --global url.https://github.com/.insteadOf ssh://git@github.com/":                                                     {},
+			"git config --global user.name Test User":                                                                                         {},
+			"git config --global user.email test@example.com":                                                                                 {},
 			"sudo mv /opt/agenthub/agenthub.service /etc/systemd/system/agenthub.service":                                                     {},
-			"sudo systemctl daemon-reload":                 {},
-			"sudo systemctl enable --now agenthub.service": {},
+			"sudo systemctl daemon-reload":                                                                                                    {},
+			"sudo systemctl enable --now agenthub.service":                                                                                    {},
 		},
 	}
 
@@ -253,6 +258,7 @@ func TestInstallerConfiguresGitHubCredentialHelperForUserAuth(t *testing.T) {
 				AuthMode:       config.GitHubAuthModeUser,
 				TokenSecretARN: "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:agenthub/github-token",
 			},
+			Git:     config.GitConfig{Name: "Test User", Email: "test@example.com"},
 			Sandbox: config.SandboxConfig{Enabled: true, NetworkMode: "private", UseNemoClaw: true},
 		},
 		WorkingDir: "/opt/agenthub",

--- a/internal/setup/github.go
+++ b/internal/setup/github.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -18,6 +19,14 @@ var gitRemoteOriginURLFunc = defaultGitRemoteOriginURL
 var runGitHubAuthLoginFunc = defaultRunGitHubAuthLogin
 var runGitHubAuthTokenFunc = defaultRunGitHubAuthToken
 var storeGitHubTokenFunc = defaultStoreGitHubToken
+var runGitHubAPIUserFunc = defaultRunGitHubAPIUser
+var runGitHubAPIUserEmailsFunc = defaultRunGitHubAPIUserEmails
+var LookupGitIdentityFunc = lookupGitIdentity
+
+type GitIdentity struct {
+	Name  string
+	Email string
+}
 
 func detectGitHubRepoSlug(ctx context.Context) (string, error) {
 	remoteURL, err := gitRemoteOriginURLFunc(ctx)
@@ -106,6 +115,59 @@ func defaultRunGitHubAuthToken(ctx context.Context) (string, error) {
 	return token, nil
 }
 
+func defaultRunGitHubAPIUser(ctx context.Context) (GitIdentity, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return GitIdentity{}, errors.New("gh CLI is required for GitHub identity lookup")
+	}
+	cmd := exec.CommandContext(ctx, "gh", "api", "user")
+	out, err := cmd.Output()
+	if err != nil {
+		return GitIdentity{}, fmt.Errorf("run gh api user: %w", err)
+	}
+	var payload struct {
+		Name  string `json:"name"`
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return GitIdentity{}, fmt.Errorf("parse gh api user response: %w", err)
+	}
+	name := strings.TrimSpace(payload.Name)
+	if name == "" {
+		name = strings.TrimSpace(payload.Login)
+	}
+	return GitIdentity{Name: name}, nil
+}
+
+func defaultRunGitHubAPIUserEmails(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return "", errors.New("gh CLI is required for GitHub identity lookup")
+	}
+	cmd := exec.CommandContext(ctx, "gh", "api", "user/emails")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("run gh api user/emails: %w", err)
+	}
+	var emails []struct {
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
+	}
+	if err := json.Unmarshal(out, &emails); err != nil {
+		return "", fmt.Errorf("parse gh api user/emails response: %w", err)
+	}
+	for _, email := range emails {
+		if email.Primary && email.Verified && strings.TrimSpace(email.Email) != "" {
+			return strings.TrimSpace(email.Email), nil
+		}
+	}
+	for _, email := range emails {
+		if strings.TrimSpace(email.Email) != "" {
+			return strings.TrimSpace(email.Email), nil
+		}
+	}
+	return "", errors.New("gh api user/emails did not return an email")
+}
+
 func defaultStoreGitHubToken(ctx context.Context, profile, region, secretName, token string) (string, error) {
 	return githubauth.StoreToken(ctx, profile, region, secretName, token)
 }
@@ -131,6 +193,25 @@ func bootstrapGitHubUserAuth(ctx context.Context, profile, region, repoSlug stri
 		AuthMode:       config.GitHubAuthModeUser,
 		TokenSecretARN: arn,
 	}, nil
+}
+
+func lookupGitIdentity(ctx context.Context) (GitIdentity, error) {
+	identity := GitIdentity{}
+	user, err := runGitHubAPIUserFunc(ctx)
+	if err == nil {
+		identity.Name = strings.TrimSpace(user.Name)
+	}
+	email, err := runGitHubAPIUserEmailsFunc(ctx)
+	if err == nil {
+		identity.Email = strings.TrimSpace(email)
+	}
+	if strings.TrimSpace(identity.Name) == "" && strings.TrimSpace(identity.Email) == "" {
+		if err != nil {
+			return GitIdentity{}, err
+		}
+		return GitIdentity{}, errors.New("github identity lookup returned no usable values")
+	}
+	return identity, nil
 }
 
 func defaultGitHubUserSecretName(repoSlug string) string {

--- a/internal/setup/github_test.go
+++ b/internal/setup/github_test.go
@@ -91,6 +91,54 @@ func TestBootstrapGitHubUserAuthStoresTokenSecret(t *testing.T) {
 	}
 }
 
+func TestLookupGitIdentityUsesGitHubCLI(t *testing.T) {
+	originalUser := runGitHubAPIUserFunc
+	originalEmails := runGitHubAPIUserEmailsFunc
+	defer func() {
+		runGitHubAPIUserFunc = originalUser
+		runGitHubAPIUserEmailsFunc = originalEmails
+	}()
+
+	runGitHubAPIUserFunc = func(ctx context.Context) (GitIdentity, error) {
+		return GitIdentity{Name: "Test User"}, nil
+	}
+	runGitHubAPIUserEmailsFunc = func(ctx context.Context) (string, error) {
+		return "test@example.com", nil
+	}
+
+	got, err := lookupGitIdentity(context.Background())
+	if err != nil {
+		t.Fatalf("lookupGitIdentity() error = %v", err)
+	}
+	if got.Name != "Test User" || got.Email != "test@example.com" {
+		t.Fatalf("lookupGitIdentity() = %+v, want Test User/test@example.com", got)
+	}
+}
+
+func TestLookupGitIdentityFallsBackWhenEmailMissing(t *testing.T) {
+	originalUser := runGitHubAPIUserFunc
+	originalEmails := runGitHubAPIUserEmailsFunc
+	defer func() {
+		runGitHubAPIUserFunc = originalUser
+		runGitHubAPIUserEmailsFunc = originalEmails
+	}()
+
+	runGitHubAPIUserFunc = func(ctx context.Context) (GitIdentity, error) {
+		return GitIdentity{Name: "Test User"}, nil
+	}
+	runGitHubAPIUserEmailsFunc = func(ctx context.Context) (string, error) {
+		return "", errors.New("no email")
+	}
+
+	got, err := lookupGitIdentity(context.Background())
+	if err != nil {
+		t.Fatalf("lookupGitIdentity() error = %v", err)
+	}
+	if got.Name != "Test User" || got.Email != "" {
+		t.Fatalf("lookupGitIdentity() = %+v, want Test User/empty email", got)
+	}
+}
+
 func TestDetectGitHubRepoSlugFromRemoteURL(t *testing.T) {
 	original := gitRemoteOriginURLFunc
 	defer func() { gitRemoteOriginURLFunc = original }()

--- a/internal/setup/github_test_main_test.go
+++ b/internal/setup/github_test_main_test.go
@@ -1,0 +1,19 @@
+package setup
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	originalLookup := LookupGitIdentityFunc
+	LookupGitIdentityFunc = func(ctx context.Context) (GitIdentity, error) {
+		return GitIdentity{Name: "Test User", Email: "test@example.com"}, nil
+	}
+
+	code := m.Run()
+
+	LookupGitIdentityFunc = originalLookup
+	os.Exit(code)
+}

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -235,6 +235,11 @@ func (w *Wizard) Run(ctx context.Context) (*config.Config, error) {
 	if err == nil && strings.TrimSpace(repoSlug) != "" {
 		w.logLine("Access", "!", fmt.Sprintf("detected GitHub repo candidate: %s", repoSlug))
 	}
+	gitIdentity := config.GitConfig{}
+	if detected, detectErr := LookupGitIdentityFunc(ctx); detectErr == nil {
+		gitIdentity.Name = strings.TrimSpace(detected.Name)
+		gitIdentity.Email = strings.TrimSpace(detected.Email)
+	}
 	w.logLine("Access", "⇒", "GitHub connectivity is required for deployed agents.")
 	w.logLine("Access", "⇒", "GitHub App auth is recommended for shared or production environments.")
 	githubCfg := config.GitHubConfig{}
@@ -278,6 +283,19 @@ func (w *Wizard) Run(ctx context.Context) (*config.Config, error) {
 			return nil, err
 		}
 		githubCfg.TokenSecretARN = ""
+	}
+
+	if gitIdentity.Name == "" {
+		gitIdentity.Name, err = w.Prompter.Text("Git author name", "")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if gitIdentity.Email == "" {
+		gitIdentity.Email, err = w.Prompter.Text("Git author email", "")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	useNemoClaw, err := w.Prompter.Confirm("Use NemoClaw", true)
@@ -340,6 +358,7 @@ func (w *Wizard) Run(ctx context.Context) (*config.Config, error) {
 			ModuleDir: defaultTerraformModuleDir(platform),
 		},
 		GitHub: githubCfg,
+		Git:    gitIdentity,
 		Sandbox: config.SandboxConfig{
 			Enabled:     true,
 			NetworkMode: networkMode,
@@ -413,6 +432,9 @@ func (w *Wizard) Run(ctx context.Context) (*config.Config, error) {
 		default:
 			fmt.Fprintf(w.Out, "- github auth: %s\n", valueOrDash(cfg.GitHub.AuthMode))
 		}
+	}
+	if strings.TrimSpace(cfg.Git.Name) != "" || strings.TrimSpace(cfg.Git.Email) != "" {
+		fmt.Fprintf(w.Out, "- git author: %s / %s\n", valueOrDash(cfg.Git.Name), valueOrDash(cfg.Git.Email))
 	}
 
 	confirm, err := w.Prompter.Confirm("Write this configuration", true)

--- a/internal/setup/wizard_test.go
+++ b/internal/setup/wizard_test.go
@@ -744,6 +744,8 @@ func TestWizardConfiguresGitHubUserAuthFromRepoOrigin(t *testing.T) {
 		"",
 		"",
 		"2", // select user auth
+		"",
+		"",
 		"y", // use NemoClaw
 		"1", // provider codex
 		"http://localhost:11434",
@@ -810,6 +812,8 @@ func TestWizardDefaultsGitHubAuthToApp(t *testing.T) {
 		"123456",
 		"789012",
 		"arn:aws:secretsmanager:us-east-1:123456789012:secret:agenthub/github-app-private-key",
+		"",
+		"",
 		"y", // use NemoClaw
 		"1", // provider codex
 		"http://localhost:11434",


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #127 

## Overview

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->
What changed:

  - init now tries to resolve git identity from GitHub CLI/API:
      - gh api user for name or fallback login
      - gh api user/emails for primary verified email, then fallback email
  - The resolved identity is stored in config under a new git section:
      - git.name
      - git.email
  - Runtime install now writes the identity onto the instance with:
      - git config --global user.name
      - git config --global user.email
  - Existing GitHub auth and clone logic were left unchanged.

  Files updated:

  - internal/config/config.go
  - internal/setup/github.go
  - internal/setup/wizard.go
  - internal/runtimeinstall/install.go
  - Tests were added/updated in config, setup, runtimeinstall, and init flows.

  Verification:

  - go test ./internal/config ./internal/setup ./internal/runtimeinstall ./internal/app passed.

  Behavior now:

  - If GitHub CLI/API can provide identity, init fills it automatically.
  - If not, the wizard still falls back to interactive prompts.
  - The instance gets a usable global git author identity for commit / push workflows.
  - 
<!-- close -->